### PR TITLE
Add submodule init step & README install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ https://github.com/tc39/proposal-realms .
 
 Run the test suite
 
-`npm run test`
+`npm test`
 
 ### Bug Disclosure
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ known security holes that need to be closed.
 Incorporates (as a git submodule) the Realms shim from
 https://github.com/tc39/proposal-realms .
 
+### Install
+
+`npm install`
+`npm run build`
+
+Run the test suite
+
+`npm run test`
+
 ### Bug Disclosure
 
 Despite this not being ready for production use, we'd like to get into the

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node scripts/build-intermediate.js && tape -r esm test/**/*.js",
     "just-test": "tape -r esm test/**/*.js",
     "build-intermediate": "node scripts/build-intermediate.js",
-    "build": "node scripts/build-intermediate.js && rollup --format=iife --output.name=SES --sourcemap --file=dist/ses-shim.js -- src/index.js"
+    "build": "git submodule update --init --recursive && node scripts/build-intermediate.js && rollup --format=iife --output.name=SES --sourcemap --file=dist/ses-shim.js -- src/index.js"
   },
   "devDependencies": {
     "esm": "^3.0.37",


### PR DESCRIPTION
I did see the previous PR #17 - but after reading some docs on submodules, this approach might be cleaner? No idea actually. Also wanted to add the INSTALL steps to the README.md

I am very interested in this project and will be happy to help with developer ergonomics or docs, etc