### PR TITLE
freeze primordials

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -19,6 +19,8 @@ import tameError from './tame-error.js';
 import tameRegExp from './tame-regexp.js';
 import removeProperties from './removeProperties.js';
 import getAnonIntrinsics from './anonIntrinsics.js';
+import { deepFreeze } from './deepFreeze.js';
+import hardenPrimordials from './hardenPrimordials.js';
 import whitelist from './whitelist.js';
 
 export function createSESWithRealmConstructor(creatorStrings, Realm) {
@@ -87,7 +89,12 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
     r.global.def = b.def;
     r.global.Nat = b.Nat;
 
-    b.deepFreezePrimordials(r.global);
+    const hardenPrimordialsSrc = `
+      const deepFreeze = (${deepFreeze});
+      const getAnonIntrinsics = (${getAnonIntrinsics});
+      (${hardenPrimordials})`;
+    r.evaluate(hardenPrimordialsSrc)(r.global);
+    //b.deepFreezePrimordials(r.global);
     return r;
   }
   const SES = {

--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -46,7 +46,7 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       shims.push(`(${tameIntl})();`);
     } else {
       /*
-      wl.Intl = {
+      wl.namedIntrinsics.Intl = {
         Collator: true,
         DateTimeFormat: true,
         NumberFormat: true,
@@ -64,9 +64,9 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       // uncaught exceptions as "undefined" instead of a type/message/stack.
       // So if we're allowing stack traces, make sure the whitelist is
       // augmented to include them.
-      wl.Error.captureStackTrace = true;
-      wl.Error.stackTraceLimit = true;
-      wl.Error.prepareStackTrace = true;
+      wl.namedIntrinsics.Error.captureStackTrace = true;
+      wl.namedIntrinsics.Error.stackTraceLimit = true;
+      wl.namedIntrinsics.Error.prepareStackTrace = true;
     }
 
     if (options.regexpMode !== "allow") {

--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -94,7 +94,6 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       const getAnonIntrinsics = (${getAnonIntrinsics});
       (${hardenPrimordials})`;
     r.evaluate(hardenPrimordialsSrc)(r.global);
-    //b.deepFreezePrimordials(r.global);
     return r;
   }
   const SES = {

--- a/src/bundle/hardenPrimordials.js
+++ b/src/bundle/hardenPrimordials.js
@@ -1,0 +1,14 @@
+/* global def getAnonIntrinsics deepFreeze */
+
+export default function hardenPrimoridals(global) {
+  "use strict";
+  const root = {
+    global, // global plus all the namedIntrinsics
+    anonIntrinsics: getAnonIntrinsics(global),
+  };
+  // todo: re-examine exactly which "global" we're freezing
+
+  // this will change when we redefine def() into a harden() with a different
+  // API (which does not traverse .__proto__)
+  deepFreeze(root);
+}

--- a/src/bundle/index.js
+++ b/src/bundle/index.js
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 import { createSESWithRealmConstructor, createSESInThisRealm } from './createSES.js';
-import { deepFreezePrimordials } from './deepFreeze.js';
 import { def } from './def.js';
 import { Nat } from './nat.js';
 
 export { createSESWithRealmConstructor, createSESInThisRealm,
-         deepFreezePrimordials,
          def, Nat
        };

--- a/src/bundle/removeProperties.js
+++ b/src/bundle/removeProperties.js
@@ -150,8 +150,8 @@ export default function removeProperties(global, whitelist) {
     });
   }
 
-  addToWhiteTable(global, whitelist);
+  addToWhiteTable(global, whitelist.namedIntrinsics);
   const intr = getAnonIntrinsics(global);
-  addToWhiteTable(intr, whitelist.cajaVM.anonIntrinsics);
+  addToWhiteTable(intr, whitelist.anonIntrinsics);
   clean(global, '', 0);
 }

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -109,133 +109,98 @@ const j = true;  // included in the Jessie runtime
 let TypedArrayWhitelist;  // defined and used below
 
 export default {
-    cajaVM: {                        // Caja support
-      // The accessible intrinsics which are not reachable by own
-      // property name traversal are listed here so that they are
-      // processed by the whitelist, although this also makes them
-      // accessible by this path.  See
-      // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects
-      // Of these, ThrowTypeError is the only one from ES5. All the
-      // rest were introduced in ES6.
-      anonIntrinsics: {
-        ThrowTypeError: {},
-        IteratorPrototype: {  // 25.1
-          // Technically, for SES-on-ES5, we should not need to
-          // whitelist 'next'. However, browsers are accidentally
-          // relying on it
-          // https://bugs.chromium.org/p/v8/issues/detail?id=4769#
-          // https://bugs.webkit.org/show_bug.cgi?id=154475
-          // and we will be whitelisting it as we transition to ES6
-          // anyway, so we unconditionally whitelist it now.
+  // The accessible intrinsics which are not reachable by own
+  // property name traversal are listed here so that they are
+  // processed by the whitelist, although this also makes them
+  // accessible by this path.  See
+  // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-intrinsic-objects
+  // Of these, ThrowTypeError is the only one from ES5. All the
+  // rest were introduced in ES6.
+  anonIntrinsics: {
+    ThrowTypeError: {},
+    IteratorPrototype: {  // 25.1
+      // Technically, for SES-on-ES5, we should not need to
+      // whitelist 'next'. However, browsers are accidentally
+      // relying on it
+      // https://bugs.chromium.org/p/v8/issues/detail?id=4769#
+      // https://bugs.webkit.org/show_bug.cgi?id=154475
+      // and we will be whitelisting it as we transition to ES6
+      // anyway, so we unconditionally whitelist it now.
+      next: '*',
+      constructor: false
+    },
+    ArrayIteratorPrototype: {},
+    StringIteratorPrototype: {},
+    MapIteratorPrototype: {},
+    SetIteratorPrototype: {},
+
+    // The %GeneratorFunction% intrinsic is the constructor of
+    // generator functions, so %GeneratorFunction%.prototype is
+    // the %Generator% intrinsic, which all generator functions
+    // inherit from. A generator function is effectively the
+    // constructor of its generator instances, so, for each
+    // generator function (e.g., "g1" on the diagram at
+    // http://people.mozilla.org/~jorendorff/figure-2.png )
+    // its .prototype is a prototype that its instances inherit
+    // from. Paralleling this structure, %Generator%.prototype,
+    // i.e., %GeneratorFunction%.prototype.prototype, is the
+    // object that all these generator function prototypes inherit
+    // from. The .next, .return and .throw that generator
+    // instances respond to are actually the builtin methods they
+    // inherit from this object.
+    GeneratorFunction: {  // 25.2
+      length: '*',  // Not sure why this is needed
+      prototype: {  // 25.3
+        prototype: {
           next: '*',
-          constructor: false
-        },
-        ArrayIteratorPrototype: {},
-        StringIteratorPrototype: {},
-        MapIteratorPrototype: {},
-        SetIteratorPrototype: {},
-
-        // The %GeneratorFunction% intrinsic is the constructor of
-        // generator functions, so %GeneratorFunction%.prototype is
-        // the %Generator% intrinsic, which all generator functions
-        // inherit from. A generator function is effectively the
-        // constructor of its generator instances, so, for each
-        // generator function (e.g., "g1" on the diagram at
-        // http://people.mozilla.org/~jorendorff/figure-2.png )
-        // its .prototype is a prototype that its instances inherit
-        // from. Paralleling this structure, %Generator%.prototype,
-        // i.e., %GeneratorFunction%.prototype.prototype, is the
-        // object that all these generator function prototypes inherit
-        // from. The .next, .return and .throw that generator
-        // instances respond to are actually the builtin methods they
-        // inherit from this object.
-        GeneratorFunction: {  // 25.2
-          length: '*',  // Not sure why this is needed
-          prototype: {  // 25.3
-            prototype: {
-              next: '*',
-              return: '*',
-              throw: '*',
-              constructor: '*'  // Not sure why this is needed
-            }
-          }
-        },
-        // TODO: 25.5 AsyncFunction
-
-        TypedArray: TypedArrayWhitelist = {  // 22.2
-          length: '*',  // does not inherit from Function.prototype on Chrome
-          name: '*',  // ditto
-          from: t,
-          of: t,
-          BYTES_PER_ELEMENT: '*',
-          prototype: {
-            buffer: 'maybeAccessor',
-            byteLength: 'maybeAccessor',
-            byteOffset: 'maybeAccessor',
-            copyWithin: '*',
-            entries: '*',
-            every: '*',
-            fill: '*',
-            filter: '*',
-            find: '*',
-            findIndex: '*',
-            forEach: '*',
-            includes: '*',
-            indexOf: '*',
-            join: '*',
-            keys: '*',
-            lastIndexOf: '*',
-            length: 'maybeAccessor',
-            map: '*',
-            reduce: '*',
-            reduceRight: '*',
-            reverse: '*',
-            set: '*',
-            slice: '*',
-            some: '*',
-            sort: '*',
-            subarray: '*',
-            values: '*',
-            BYTES_PER_ELEMENT: '*'
-          }
+          return: '*',
+          throw: '*',
+          constructor: '*'  // Not sure why this is needed
         }
-      },
-
-      log: t,
-      tamperProof: t,
-      constFunc: t,
-      Nat: j,
-      def: j,
-      is: t,
-
-      compileExpr: t,
-      confine: j,
-      compileModule: t,              // experimental
-      compileProgram: t,             // Cannot be implemented in just ES5.1.
-      eval: t,
-      Function: t,
-
-      sharedImports: t,
-      makeImports: t,
-      copyToImports: t,
-
-      GuardT: {
-        coerce: t
-      },
-      makeTableGuard: t,
-      Trademark: {
-        stamp: t
-      },
-      guard: t,
-      passesGuard: t,
-      stamp: t,
-      makeSealerUnsealerPair: t,
-
-      makeArrayLike: {
-        canBeFullyLive: t
       }
     },
+    // TODO: 25.5 AsyncFunction, also AsyncIterator
 
+    TypedArray: TypedArrayWhitelist = {  // 22.2
+      length: '*',  // does not inherit from Function.prototype on Chrome
+      name: '*',  // ditto
+      from: t,
+      of: t,
+      BYTES_PER_ELEMENT: '*',
+      prototype: {
+        buffer: 'maybeAccessor',
+        byteLength: 'maybeAccessor',
+        byteOffset: 'maybeAccessor',
+        copyWithin: '*',
+        entries: '*',
+        every: '*',
+        fill: '*',
+        filter: '*',
+        find: '*',
+        findIndex: '*',
+        forEach: '*',
+        includes: '*',
+        indexOf: '*',
+        join: '*',
+        keys: '*',
+        lastIndexOf: '*',
+        length: 'maybeAccessor',
+        map: '*',
+        reduce: '*',
+        reduceRight: '*',
+        reverse: '*',
+        set: '*',
+        slice: '*',
+        some: '*',
+        sort: '*',
+        subarray: '*',
+        values: '*',
+        BYTES_PER_ELEMENT: '*'
+      }
+    }
+  },
+
+  namedIntrinsics: {
     // In order according to
     // http://www.ecma-international.org/ecma-262/ with chapter
     // numbers where applicable
@@ -843,13 +808,22 @@ export default {
                     // needlessly expensive for current usage.
     },
 
-    Realm: { makeRootRealm: t,
-             makeCompartment: t,
-             prototype: { global: "maybeAccessor",
-                          evaluate: t
-                        }
-           },
-    SES: { confine: t,
-           confineExpr: t
-         }
-  };
+    Realm: {
+      makeRootRealm: t,
+      makeCompartment: t,
+      prototype: {
+        global: "maybeAccessor",
+        evaluate: t
+      }
+    },
+
+    SES: {
+      confine: t,
+      confineExpr: t
+    },
+
+    Nat: j,
+    def: j
+  }
+
+};

--- a/test/test-freeze.js
+++ b/test/test-freeze.js
@@ -1,0 +1,34 @@
+import test from 'tape';
+import SES from '../src/index.js';
+
+test('SESRealm global is frozen', function(t) {
+  const s = SES.makeSESRootRealm();
+  t.throws(() => s.evaluate('this.a = 10;'), TypeError);
+  t.equal(s.evaluate('this.a'), undefined);
+  t.end();
+});
+
+test('SESRealm named intrinsics are frozen', function(t) {
+  const s = SES.makeSESRootRealm();
+  t.throws(() => s.evaluate('Object.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('Number.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('Date.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('Array.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('Array.push = 10;'), TypeError);
+  t.throws(() => s.evaluate('WeakSet.a = 10;'), TypeError);
+  t.end();
+});
+
+test('SESRealm anonymous intrinsics are frozen', function(t) {
+  const s = SES.makeSESRootRealm();
+  // these two will be frozen once #41 is fixed
+  //t.throws(() => s.evaluate('(async function() {}).constructor.a = 10;'), TypeError);
+  //t.throws(() => s.evaluate('(async function*() {}).constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('(function*() {}).constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('[][Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('new Map()[Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('new Set()[Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('new WeakMap()[Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.throws(() => s.evaluate('new WeakSet()[Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.end();
+});

--- a/test/test-nesting.js
+++ b/test/test-nesting.js
@@ -1,0 +1,11 @@
+import test from 'tape';
+import SES from '../src/index.js';
+
+test('nested realms should work at all', function(t) {
+  const s1 = SES.makeSESRootRealm();
+  const s2 = s1.evaluate('SES.makeSESRootRealm()');
+  t.equal(s2.evaluate('1+2'), 3);
+  const s3 = s2.evaluate('SES.makeSESRootRealm()');
+  t.equal(s3.evaluate('1+2'), 3);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -65,13 +65,6 @@ test('SESRealm.SES wraps exceptions', function(t) {
   t.end();
 });
 
-test('SESRealm is frozen', function(t) {
-  const s = SES.makeSESRootRealm();
-  t.throws(() => s.evaluate('this.a = 10;'), TypeError);
-  t.equal(s.evaluate('this.a'), undefined);
-  t.end();
-});
-
 test('primal realm SES does not have confine', function(t) {
   t.equal(Object.hasOwnProperty('SES'), false);
   t.end();


### PR DESCRIPTION
This switches the way we freeze primordials to include the "anonmyous intrinsics", like `%MapIterator%` and `%GeneratorFunction%`. We must execute code to reach these, as they are not reachable by normal property/prototype lookup.
