### PR TITLE
Make Small Changes Only (Whitespace, etc.)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 # Proposal Realms
 /proposal-realms
+
+/dist/ses-shim.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,9 @@ module.exports = {
     'implicit-arrow-linebreak': 'off',
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
+
+    /// temporarily turn off until a decision is made
+    'prefer-arrow-callback': 'off',
+    strict: 'off',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,3 +14,4 @@ module.exports = {
     strict: 'off',
   },
 };
+

--- a/demo/demo-start.js
+++ b/demo/demo-start.js
@@ -23,12 +23,13 @@ function start() {
   function delayMS(count) {
     // busywait for 'count' milliseconds
     const target = Date.now() + count;
-    while (Date.now() < target) {
-    }
+    while (Date.now() < target) {}
   }
 
   function refreshUI() {
-    return new Promise((resolve, reject) => window.setTimeout(resolve, 0, undefined));
+    return new Promise((resolve, reject) =>
+      window.setTimeout(resolve, 0, undefined),
+    );
   }
 
   const attackerGuess = document.getElementById('guess');
@@ -38,9 +39,9 @@ function start() {
 
   function setLaunch(status) {
     if (status) {
-      document.getElementById("guess-box").className = "code-box launched";
+      document.getElementById('guess-box').className = 'code-box launched';
     } else {
-      document.getElementById("guess-box").className = "code-box";
+      document.getElementById('guess-box').className = 'code-box';
     }
   }
 
@@ -62,15 +63,23 @@ function start() {
 
   // build the SES Realm and evaluate the defender inside
   const options = {};
-  document.getElementById('dateNowStatus').textContent = 'Date.now() returns NaN';
+  document.getElementById('dateNowStatus').textContent =
+    'Date.now() returns NaN';
   if (window.location.search.indexOf('dateNow=enabled') !== -1) {
     document.getElementById('dateNowStatus').textContent = 'Date.now() enabled';
-    options.dateNowMode = "allow";
+    options.dateNowMode = 'allow';
   }
-  options.consoleMode = "allow";
+  options.consoleMode = 'allow';
   const r = SES.makeSESRootRealm(options);
   const defenderSrc = buildDefenderSrc();
-  const d = r.evaluate(defenderSrc, { getRandomValues, setMacguffinText, delayMS, refreshUI, setAttackerGuess, setLaunch });
+  const d = r.evaluate(defenderSrc, {
+    getRandomValues,
+    setMacguffinText,
+    delayMS,
+    refreshUI,
+    setAttackerGuess,
+    setLaunch,
+  });
 
   // now create the form that lets the user submit attacker code
   const ap = document.getElementById('attacker-program');
@@ -82,7 +91,9 @@ function start() {
     console.log('executing attacker code:', code);
     d.stopAttacker();
     // wait a moment to make sure the running program notices the stop request
-    const wait = new Promise((resolve, reject) => window.setTimeout(resolve, 10, undefined));
+    const wait = new Promise((resolve, reject) =>
+      window.setTimeout(resolve, 10, undefined),
+    );
     wait.then(() => d.submitProgram(code));
   });
   aStop.addEventListener('click', function stop(event) {
@@ -104,14 +115,17 @@ function start() {
     setSampleBody(`${allZeros}`);
   });
 
-  document.getElementById('sample-counter').addEventListener('click', function() {
-    setSampleBody(`${counter}`);
-  });
+  document
+    .getElementById('sample-counter')
+    .addEventListener('click', function() {
+      setSampleBody(`${counter}`);
+    });
 
-  document.getElementById('sample-timing').addEventListener('click', function() {
-    setSampleBody(`${timing}`);
-  });
-
+  document
+    .getElementById('sample-timing')
+    .addEventListener('click', function() {
+      setSampleBody(`${timing}`);
+    });
 }
 
 function sampleAttacks() {
@@ -126,32 +140,34 @@ function sampleAttacks() {
   }
 
   function counter() {
-    function *counter() {
+    function* counter() {
       for (let i = 0; true; i++) {
         let guessedCode = i.toString(36).toUpperCase();
         while (guessedCode.length < 10) {
-          guessedCode = '0' + guessedCode;
+          guessedCode = `0${guessedCode}`;
         }
         guess(guessedCode);
         yield;
-      };
+      }
     }
   }
 
   function timing() {
-    function *timing() {
+    function* timing() {
       function toChar(c) {
         return c.toString(36).toUpperCase();
       }
 
       function fastestChar(delays) {
         const pairs = Array.from(delays.entries());
-        pairs.sort((a,b) => b[1] - a[1]);
+        pairs.sort((a, b) => b[1] - a[1]);
         return pairs[0][0];
       }
 
       function insert(into, offset, char) {
-        return into.slice(0, offset) + char + into.slice(offset+1, into.length);
+        return (
+          into.slice(0, offset) + char + into.slice(offset + 1, into.length)
+        );
       }
 
       function buildCode(base, offset, c) {
@@ -159,8 +175,8 @@ function sampleAttacks() {
         // rest with random-looking junk to make the demo look cool
         // (random-looking, not truly random, because we're deterministic)
         let code = insert(base, offset, toChar(c));
-        for (let off2 = offset+1; off2 < 10; off2++) {
-          code = insert(code, off2, toChar((off2*3 + c*7) % 36));
+        for (let off2 = offset + 1; off2 < 10; off2++) {
+          code = insert(code, off2, toChar((off2 * 3 + c * 7) % 36));
         }
         return code;
       }
@@ -197,8 +213,14 @@ function sampleAttacks() {
 function buildDefenderSrc() {
   // define these to appease the syntax-highlighter in my editor. We don't
   // actually use these values.
-  let getRandomValues, setMacguffinText, delayMS, setAttackerGuess, setLaunch;
-  let SES, def, refreshUI;
+  let getRandomValues;
+  let setMacguffinText;
+  let delayMS;
+  let setAttackerGuess;
+  let setLaunch;
+  let SES;
+  let def;
+  let refreshUI;
 
   // this is stringified and loaded in the SES realm, with several endowments
   function defender() {
@@ -209,14 +231,14 @@ function buildDefenderSrc() {
       let secretCode = '';
       const SYMBOLS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
       getRandomValues(array);
-      for (let i=0; i < 10; i++) {
+      for (let i = 0; i < 10; i++) {
         // we use Uint32Array, instead of Uint8Array, to reduce the bias
         // somewhat. Actual launch codes should use a 128-bit integer before
         // wrapping down to a single digit.
         //
         // Also please use don't use this for launch codes.
         const digit = array[i] % SYMBOLS.length;
-        secretCode += SYMBOLS.slice(digit, digit+1);
+        secretCode += SYMBOLS.slice(digit, digit + 1);
       }
       return secretCode;
     }
@@ -235,8 +257,8 @@ function buildDefenderSrc() {
 
       guessedCode = `${guessedCode}`; // force into a String
       setAttackerGuess(guessedCode);
-      for (let i=0; i < 10; i++) {
-        if (secretCode.slice(i, i+1) !== guessedCode.slice(i, i+1)) {
+      for (let i = 0; i < 10; i++) {
+        if (secretCode.slice(i, i + 1) !== guessedCode.slice(i, i + 1)) {
           return false;
         }
         delayMS(10);
@@ -257,7 +279,7 @@ function buildDefenderSrc() {
       enableAttacker = true;
       setLaunch(false);
 
-      const attacker = SES.confine(program, { guess: guess });
+      const attacker = SES.confine(program, { guess });
       const attackGen = attacker(); // build the generator
       function nextGuess() {
         if (!enableAttacker) {
@@ -286,9 +308,5 @@ function buildDefenderSrc() {
   return `${defender}; defender()`;
 }
 
-
-
-
 start();
 console.log('loaded');
-

--- a/scripts/build-intermediate.js
+++ b/scripts/build-intermediate.js
@@ -2,12 +2,11 @@ const rollup = require('rollup');
 const fs = require('fs');
 
 function bundle() {
-  return rollup.rollup({input: 'src/bundle/index'}
-                      ).then(bundle =>
-                             bundle.generate({format: 'iife',
-                                              sourcemap: true,
-                                              name: 'makeBundle'
-                                             }));
+  return rollup
+    .rollup({ input: 'src/bundle/index' })
+    .then(bundle =>
+      bundle.generate({ format: 'iife', sourcemap: true, name: 'makeBundle' }),
+    );
 }
 
 function process(code, map) {
@@ -24,8 +23,8 @@ function process(code, map) {
   // invoke
 
   // todo: use a regexp instead
-  //console.log(`original bundled code:`);
-  //console.log(code);
+  // console.log(`original bundled code:`);
+  // console.log(code);
   const prefix = 'var makeBundle = ';
   if (!code.startsWith(prefix)) {
     throw new Error('unexpected prefix');
@@ -36,8 +35,8 @@ function process(code, map) {
     throw new Error('unexpected suffix');
   }
   code = code.slice(0, code.length - suffix.length);
-  //console.log(`modified code:`);
-  //console.log(code);
+  // console.log(`modified code:`);
+  // console.log(code);
 
   // now turn that code into a string definition: an importable module which
   // gives the importer access to the above exports-making string
@@ -47,7 +46,7 @@ function process(code, map) {
 `;
   fs.writeFileSync('src/stringifiedBundle', built);
   console.log(`wrote ${built.length} to src/stringifiedBundle`);
-  //fs.writeFileSync('src/stringifiedBundle.map', map);
+  // fs.writeFileSync('src/stringifiedBundle.map', map);
 }
 
 function build() {
@@ -65,5 +64,3 @@ function build() {
 }
 
 build();
-
-

--- a/src/bundle/anonIntrinsics.js
+++ b/src/bundle/anonIntrinsics.js
@@ -21,8 +21,6 @@
 // object X will pass this brand test when X will. This is fixed as of
 // FF Nightly 38.0a1.
 
-
-
 /**
  * <p>Qualifying platforms generally include all JavaScript platforms
  * shown on <a href="http://kangax.github.com/es5-compat-table/"
@@ -69,11 +67,12 @@
  * perturbations.
  */
 export default function getAnonIntrinsics(global) {
-  "use strict";
+  'use strict';
+
   const gopd = Object.getOwnPropertyDescriptor;
   const getProto = Object.getPrototypeOf;
 
-  //////////////// Undeniables and Intrinsics //////////////
+  // ////////////// Undeniables and Intrinsics //////////////
 
   /**
    * The undeniables are the primordial objects which are ambiently
@@ -102,11 +101,11 @@ export default function getAnonIntrinsics(global) {
   // Is the resulting object either the undeniable object, or does
   // it inherit directly from the undeniable object?
 
-  function* aStrictGenerator() {};
+  function* aStrictGenerator() {}
   const Generator = getProto(aStrictGenerator);
-  async function* aStrictAsyncGenerator() {};
+  async function* aStrictAsyncGenerator() {}
   const AsyncGenerator = getProto(aStrictAsyncGenerator);
-  async function aStrictAsyncFunction() {};
+  async function aStrictAsyncFunction() {}
   const AsyncFunctionPrototype = getProto(aStrictAsyncFunction);
 
   // TODO: this is dead code, but could be useful: make this the
@@ -114,7 +113,7 @@ export default function getAnonIntrinsics(global) {
 
   const undeniableTuples = [
     ['Object.prototype', Object.prototype, {}],
-    ['Function.prototype', Function.prototype, function(){}],
+    ['Function.prototype', Function.prototype, function() {}],
     ['Array.prototype', Array.prototype, []],
     ['RegExp.prototype', RegExp.prototype, /x/],
     ['Boolean.prototype', Boolean.prototype, true],
@@ -122,7 +121,7 @@ export default function getAnonIntrinsics(global) {
     ['String.prototype', String.prototype, 'x'],
     ['%Generator%', Generator, aStrictGenerator],
     ['%AsyncGenerator%', AsyncGenerator, aStrictAsyncGenerator],
-    ['%AsyncFunction%', AsyncFunctionPrototype, aStrictAsyncFunction]
+    ['%AsyncFunction%', AsyncFunctionPrototype, aStrictAsyncFunction],
   ];
   const undeniables = {};
 
@@ -131,16 +130,22 @@ export default function getAnonIntrinsics(global) {
     const undeniable = tuple[1];
     let start = tuple[2];
     undeniables[name] = undeniable;
-    if (start === void 0) { return; }
+    if (start === void 0) {
+      return;
+    }
     start = Object(start);
-    if (undeniable === start) { return; }
-    if (undeniable === getProto(start)) { return; }
-    throw new Error('Unexpected undeniable: ' + undeniable);
+    if (undeniable === start) {
+      return;
+    }
+    if (undeniable === getProto(start)) {
+      return;
+    }
+    throw new Error(`Unexpected undeniable: ${undeniable}`);
   });
 
   function registerIteratorProtos(registery, base, name) {
-    const iteratorSym = global.Symbol && global.Symbol.iterator ||
-        "@@iterator"; // used instead of a symbol on FF35
+    const iteratorSym =
+      (global.Symbol && global.Symbol.iterator) || '@@iterator'; // used instead of a symbol on FF35
 
     if (base[iteratorSym]) {
       const anIter = base[iteratorSym]();
@@ -151,18 +156,16 @@ export default function getAnonIntrinsics(global) {
         if (!registery.IteratorPrototype) {
           if (getProto(anIterProtoBase) !== Object.prototype) {
             throw new Error(
-              '%IteratorPrototype%.__proto__ was not Object.prototype');
+              '%IteratorPrototype%.__proto__ was not Object.prototype',
+            );
           }
           registery.IteratorPrototype = anIterProtoBase;
-        } else {
-          if (registery.IteratorPrototype !== anIterProtoBase) {
-            throw new Error('unexpected %' + name + '%.__proto__');
-          }
+        } else if (registery.IteratorPrototype !== anIterProtoBase) {
+          throw new Error(`unexpected %${name}%.__proto__`);
         }
       }
     }
   }
-
 
   /**
    * Get the intrinsics not otherwise reachable by named own property
@@ -200,7 +203,7 @@ export default function getAnonIntrinsics(global) {
       if (typeof Set === 'function') {
         registerIteratorProtos(result, new Set(), 'SetIteratorPrototype');
       }
-    }());
+    })();
 
     // Get the ES6 %GeneratorFunction% intrinsic, if present.
     (function() {
@@ -209,14 +212,16 @@ export default function getAnonIntrinsics(global) {
       }
       const GeneratorFunction = Generator.constructor;
       if (getProto(GeneratorFunction) !== Function.prototype.constructor) {
-        throw new Error('GeneratorFunction.__proto__ was not Function.prototype.constructor');
+        throw new Error(
+          'GeneratorFunction.__proto__ was not Function.prototype.constructor',
+        );
       }
       result.GeneratorFunction = GeneratorFunction;
       const genProtoBase = getProto(Generator.prototype);
       if (genProtoBase !== result.IteratorPrototype) {
         throw new Error('Unexpected Generator.prototype.__proto__');
       }
-    }());
+    })();
 
     // Get the ES6 %AsyncGeneratorFunction% intrinsic, if present.
     (function() {
@@ -225,7 +230,9 @@ export default function getAnonIntrinsics(global) {
       }
       const AsyncGeneratorFunction = AsyncGenerator.constructor;
       if (getProto(AsyncGeneratorFunction) !== Function.prototype.constructor) {
-        throw new Error('GeneratorFunction.__proto__ was not Function.prototype.constructor');
+        throw new Error(
+          'GeneratorFunction.__proto__ was not Function.prototype.constructor',
+        );
       }
       result.AsyncGeneratorFunction = AsyncGeneratorFunction;
       // it appears that the only way to get an AsyncIteratorPrototype is
@@ -235,26 +242,34 @@ export default function getAnonIntrinsics(global) {
       const agenProtoBase = getProto(AsyncGenerator.prototype);
       if (agenProtoBase !== result.AsyncIteratorPrototype) {
         throw new Error('Unexpected AsyncGenerator.prototype.__proto__');
-      }*/
-    }());
+      } */
+    })();
 
     // Get the ES6 %AsyncFunction% intrinsic, if present.
     (function() {
       if (getProto(AsyncFunctionPrototype) !== Function.prototype) {
-        throw new Error('AsyncFunctionPrototype.__proto__ was not Function.prototype');
+        throw new Error(
+          'AsyncFunctionPrototype.__proto__ was not Function.prototype',
+        );
       }
       const AsyncFunction = AsyncFunctionPrototype.constructor;
       if (getProto(AsyncFunction) !== Function.prototype.constructor) {
-        throw new Error('AsyncFunction.__proto__ was not Function.prototype.constructor');
+        throw new Error(
+          'AsyncFunction.__proto__ was not Function.prototype.constructor',
+        );
       }
       result.AsyncFunction = AsyncFunction;
-    }());
+    })();
 
     // Get the ES6 %TypedArray% intrinsic, if present.
     (function() {
-      if (!global.Float32Array) { return; }
+      if (!global.Float32Array) {
+        return;
+      }
       const TypedArray = getProto(global.Float32Array);
-      if (TypedArray === Function.prototype) { return; }
+      if (TypedArray === Function.prototype) {
+        return;
+      }
       if (getProto(TypedArray) !== Function.prototype) {
         // http://bespin.cz/~ondras/html/classv8_1_1ArrayBufferView.html
         // has me worried that someone might make such an intermediate
@@ -262,11 +277,11 @@ export default function getAnonIntrinsics(global) {
         throw new Error('TypedArray.__proto__ was not Function.prototype');
       }
       result.TypedArray = TypedArray;
-    }());
+    })();
 
-    for (let name in result) {
+    for (const name in result) {
       if (result[name] === void 0) {
-        throw new Error('Malformed intrinsic: ' + name);
+        throw new Error(`Malformed intrinsic: ${name}`);
       }
     }
 

--- a/src/bundle/deepFreeze.js
+++ b/src/bundle/deepFreeze.js
@@ -19,7 +19,6 @@
 // then copied from proposal-frozen-realms deep-freeze.js
 
 export function deepFreeze(root) {
-
   const { freeze, getOwnPropertyDescriptors, getPrototypeOf } = Object;
   const { ownKeys } = Reflect;
 
@@ -116,13 +115,13 @@ export function deepFreeze(root) {
   return root;
 }
 
-
 export function deepFreezePrimordials(global) {
-  const primordialRoots = { global,
-                            // todo: add other roots, to reach the
-                            // unreachables/"anonIntrinsics": see
-                            // whitelist.js for a list
-                            //anonIntrinsics: getAnonIntrinsics(global)
-                          };
+  const primordialRoots = {
+    global,
+    // todo: add other roots, to reach the
+    // unreachables/"anonIntrinsics": see
+    // whitelist.js for a list
+    // anonIntrinsics: getAnonIntrinsics(global)
+  };
   deepFreeze(primordialRoots);
 }

--- a/src/bundle/def.js
+++ b/src/bundle/def.js
@@ -15,7 +15,7 @@
 import { deepFreeze } from './deepFreeze.js';
 
 export function def(node) {
-  // TODO HACK return a shallow freeze unless Object.prototype is frozen. 
+  // TODO HACK return a shallow freeze unless Object.prototype is frozen.
   // This detects whether we are in a SES realm.
 
   // TODO: this currently does too much work: it doesn't remember what's been

--- a/src/bundle/hardenPrimordials.js
+++ b/src/bundle/hardenPrimordials.js
@@ -1,7 +1,8 @@
 /* global def getAnonIntrinsics deepFreeze */
 
 export default function hardenPrimoridals(global) {
-  "use strict";
+  'use strict';
+
   const root = {
     global, // global plus all the namedIntrinsics
     anonIntrinsics: getAnonIntrinsics(global),

--- a/src/bundle/index.js
+++ b/src/bundle/index.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createSESWithRealmConstructor, createSESInThisRealm } from './createSES.js';
+import {
+  createSESWithRealmConstructor,
+  createSESInThisRealm,
+} from './createSES.js';
 import { def } from './def.js';
 import { Nat } from './nat.js';
 
-export { createSESWithRealmConstructor, createSESInThisRealm,
-         def, Nat
-       };
+export { createSESWithRealmConstructor, createSESInThisRealm, def, Nat };

--- a/src/bundle/make-console.js
+++ b/src/bundle/make-console.js
@@ -1,4 +1,3 @@
-
 export function makeConsole(parentConsole) {
   /* 'parentConsole' is the parent Realm's original 'console' object. We must
      wrap it, exposing a 'console' with a 'console.log' (and perhaps others)
@@ -16,7 +15,7 @@ export function makeConsole(parentConsole) {
     ['ReferenceError', ReferenceError],
     ['SyntaxError', SyntaxError],
     ['TypeError', TypeError],
-    ['URIError', URIError]
+    ['URIError', URIError],
   ]);
 
   function callAndWrapError(target, ...args) {
@@ -27,7 +26,9 @@ export function makeConsole(parentConsole) {
         // err is a primitive value, which is safe to rethrow
         throw err;
       }
-      let eName, eMessage, eStack;
+      let eName;
+      let eMessage;
+      let eStack;
       try {
         // The child environment might seek to use 'err' to reach the
         // parent's intrinsics and corrupt them. `${err.name}` will cause
@@ -60,10 +61,18 @@ export function makeConsole(parentConsole) {
   }
 
   const newConsole = {};
-  const passThrough = ['log', 'info', 'warn', 'error',
-                       'group', 'groupEnd',
-                       'trace',
-                       'time', 'timeLog', 'timeEnd'];
+  const passThrough = [
+    'log',
+    'info',
+    'warn',
+    'error',
+    'group',
+    'groupEnd',
+    'trace',
+    'time',
+    'timeLog',
+    'timeEnd',
+  ];
   // TODO: those are the properties that MDN documents. Node.js has a bunch
   // of additional ones that I didn't include, which might be appropriate.
 
@@ -88,4 +97,3 @@ export function makeConsole(parentConsole) {
 
   return newConsole;
 }
-

--- a/src/bundle/nat.js
+++ b/src/bundle/nat.js
@@ -29,9 +29,17 @@ export function Nat(allegedNum) {
   if (typeof allegedNum !== 'number') {
     throw new RangeError('not a number');
   }
-  if (allegedNum !== allegedNum) { throw new RangeError('NaN not natural'); }
-  if (allegedNum < 0)            { throw new RangeError('negative'); }
-  if (allegedNum % 1 !== 0)      { throw new RangeError('not integral'); }
-  if (allegedNum > Number.MAX_SAFE_INTEGER) { throw new RangeError('too big'); }
+  if (allegedNum !== allegedNum) {
+    throw new RangeError('NaN not natural');
+  }
+  if (allegedNum < 0) {
+    throw new RangeError('negative');
+  }
+  if (allegedNum % 1 !== 0) {
+    throw new RangeError('not integral');
+  }
+  if (allegedNum > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError('too big');
+  }
   return allegedNum;
 }

--- a/src/bundle/tame-date.js
+++ b/src/bundle/tame-date.js
@@ -1,4 +1,3 @@
-
 export default function tameDate() {
   const unsafeDate = Date;
   // Date(anything) gives a string with the current time
@@ -21,10 +20,12 @@ export default function tameDate() {
     return Reflect.construct(unsafeDate, [NaN], new.target);
   };
 
-  Object.defineProperties(newDateConstructor,
-                          Object.getOwnPropertyDescriptors(unsafeDate));
+  Object.defineProperties(
+    newDateConstructor,
+    Object.getOwnPropertyDescriptors(unsafeDate),
+  );
   // that will copy the .prototype too, so this next line is unnecessary
-  //newDateConstructor.prototype = unsafeDate.prototype;
+  // newDateConstructor.prototype = unsafeDate.prototype;
   unsafeDate.prototype.constructor = newDateConstructor;
   // disable Date.now
   newDateConstructor.now = () => NaN;

--- a/src/bundle/tame-error.js
+++ b/src/bundle/tame-error.js
@@ -1,6 +1,5 @@
-
 export default function tameError() {
-  if (!(Object.isExtensible(Error))) {
+  if (!Object.isExtensible(Error)) {
     throw Error('huh Error is not extensible');
   }
   /* this worked back when we were running it on a global, but stopped

--- a/src/bundle/tame-intl.js
+++ b/src/bundle/tame-intl.js
@@ -8,9 +8,15 @@ export default function tameIntl() {
 
   // the whitelist may have deleted Intl entirely, so tolerate that
   if (typeof Intl !== 'undefined') {
-    Intl.DateTimeFormat = () => { throw Error("disabled"); };
-    Intl.NumberFormat = () => { throw Error("disabled"); };
-    Intl.getCanonicalLocales = () => { throw Error("disabled"); };
+    Intl.DateTimeFormat = () => {
+      throw Error('disabled');
+    };
+    Intl.NumberFormat = () => {
+      throw Error('disabled');
+    };
+    Intl.getCanonicalLocales = () => {
+      throw Error('disabled');
+    };
   }
   Object.prototype.toLocaleString = () => {
     throw new Error('toLocaleString suppressed');

--- a/src/bundle/tame-math.js
+++ b/src/bundle/tame-math.js
@@ -1,5 +1,6 @@
-
 export default function tameMath() {
-  //Math.random = () => 4; // https://www.xkcd.com/221
-  Math.random = () => { throw Error("disabled"); };
+  // Math.random = () => 4; // https://www.xkcd.com/221
+  Math.random = () => {
+    throw Error('disabled');
+  };
 }

--- a/src/bundle/tame-regexp.js
+++ b/src/bundle/tame-regexp.js
@@ -1,4 +1,3 @@
-
 export default function tameRegExp() {
   delete RegExp.prototype.compile;
   if ('compile' in RegExp.prototype) {
@@ -18,5 +17,4 @@ export default function tameRegExp() {
   if ('$1' in RegExp) {
     throw Error('hey we could not remove RegExp.$1');
   }
-
 }

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -104,9 +104,9 @@
  */
 
 const t = true;
-const j = true;  // included in the Jessie runtime
+const j = true; // included in the Jessie runtime
 
-let TypedArrayWhitelist;  // defined and used below
+let TypedArrayWhitelist; // defined and used below
 
 export default {
   // The accessible intrinsics which are not reachable by own
@@ -118,7 +118,8 @@ export default {
   // rest were introduced in ES6.
   anonIntrinsics: {
     ThrowTypeError: {},
-    IteratorPrototype: {  // 25.1
+    IteratorPrototype: {
+      // 25.1
       // Technically, for SES-on-ES5, we should not need to
       // whitelist 'next'. However, browsers are accidentally
       // relying on it
@@ -127,7 +128,7 @@ export default {
       // and we will be whitelisting it as we transition to ES6
       // anyway, so we unconditionally whitelist it now.
       next: '*',
-      constructor: false
+      constructor: false,
     },
     ArrayIteratorPrototype: {},
     StringIteratorPrototype: {},
@@ -148,36 +149,42 @@ export default {
     // from. The .next, .return and .throw that generator
     // instances respond to are actually the builtin methods they
     // inherit from this object.
-    GeneratorFunction: {  // 25.2
-      length: '*',  // Not sure why this is needed
-      prototype: {  // 25.4
+    GeneratorFunction: {
+      // 25.2
+      length: '*', // Not sure why this is needed
+      prototype: {
+        // 25.4
         prototype: {
           next: '*',
           return: '*',
           throw: '*',
-          constructor: '*'  // Not sure why this is needed
-        }
-      }
+          constructor: '*', // Not sure why this is needed
+        },
+      },
     },
-    AsyncGeneratorFunction: {  // 25.3
+    AsyncGeneratorFunction: {
+      // 25.3
       length: '*',
-      prototype: {  // 25.5
+      prototype: {
+        // 25.5
         prototype: {
           next: '*',
           return: '*',
           throw: '*',
-          constructor: '*'  // Not sure why this is needed
-        }
-      }
+          constructor: '*', // Not sure why this is needed
+        },
+      },
     },
-    AsyncFunction: { // 25.7
+    AsyncFunction: {
+      // 25.7
       length: '*',
       prototype: '*',
     },
 
-    TypedArray: TypedArrayWhitelist = {  // 22.2
-      length: '*',  // does not inherit from Function.prototype on Chrome
-      name: '*',  // ditto
+    TypedArray: (TypedArrayWhitelist = {
+      // 22.2
+      length: '*', // does not inherit from Function.prototype on Chrome
+      name: '*', // ditto
       from: t,
       of: t,
       BYTES_PER_ELEMENT: '*',
@@ -209,16 +216,15 @@ export default {
         sort: '*',
         subarray: '*',
         values: '*',
-        BYTES_PER_ELEMENT: '*'
-      }
-    }
+        BYTES_PER_ELEMENT: '*',
+      },
+    }),
   },
 
   namedIntrinsics: {
     // In order according to
     // http://www.ecma-international.org/ecma-262/ with chapter
     // numbers where applicable
-
 
     // 18 The Global Object
 
@@ -229,7 +235,7 @@ export default {
 
     // 18.2
     // eval: t,                      // Whitelisting under separate control
-                                     // by TAME_GLOBAL_EVAL in startSES.js
+    // by TAME_GLOBAL_EVAL in startSES.js
     isFinite: t,
     isNaN: t,
     parseFloat: t,
@@ -239,33 +245,32 @@ export default {
     encodeURI: t,
     encodeURIComponent: t,
 
-
     // 19 Fundamental Objects
 
-    Object: {  // 19.1
-      assign: t,                     // ES-Harmony
+    Object: {
+      // 19.1
+      assign: t, // ES-Harmony
       create: t,
-      defineProperties: t,           // ES-Harmony
+      defineProperties: t, // ES-Harmony
       defineProperty: t,
-      entries: t,                    // ES-Harmony
+      entries: t, // ES-Harmony
       freeze: j,
       getOwnPropertyDescriptor: t,
-      getOwnPropertyDescriptors: t,  // proposed ES-Harmony
+      getOwnPropertyDescriptors: t, // proposed ES-Harmony
       getOwnPropertyNames: t,
-      getOwnPropertySymbols: t,      // ES-Harmony
+      getOwnPropertySymbols: t, // ES-Harmony
       getPrototypeOf: t,
-      is: j,                         // ES-Harmony
+      is: j, // ES-Harmony
       isExtensible: t,
       isFrozen: t,
       isSealed: t,
       keys: t,
       preventExtensions: j,
       seal: j,
-      setPrototypeOf: t,             // ES-Harmony
-      values: t,                     // ES-Harmony
+      setPrototypeOf: t, // ES-Harmony
+      values: t, // ES-Harmony
 
       prototype: {
-
         // B.2.2
         // __proto__: t, whitelisted manually in startSES.js
         __defineGetter__: t,
@@ -285,11 +290,12 @@ export default {
         [Symbol.iterator]: '*',
         [Symbol.toPrimitive]: '*',
         [Symbol.toStringTag]: '*',
-        [Symbol.unscopables]: '*'
-      }
+        [Symbol.unscopables]: '*',
+      },
     },
 
-    Function: {  // 19.2
+    Function: {
+      // 19.2
       length: t,
       prototype: {
         apply: t,
@@ -299,21 +305,23 @@ export default {
 
         // 19.2.4 instances
         length: '*',
-        name: '*',                   // ES-Harmony
+        name: '*', // ES-Harmony
         prototype: '*',
-        arity: '*',                   // non-std, deprecated in favor of length
+        arity: '*', // non-std, deprecated in favor of length
 
         // Generally allowed
-        [Symbol.species]: 'maybeAccessor'  // ES-Harmony?
-      }
+        [Symbol.species]: 'maybeAccessor', // ES-Harmony?
+      },
     },
 
-    Boolean: {  // 19.3
-      prototype: t
+    Boolean: {
+      // 19.3
+      prototype: t,
     },
 
-    Symbol: {  // 19.4               all ES-Harmony
-      asyncIterator: t,              // proposed? ES-Harmony
+    Symbol: {
+      // 19.4               all ES-Harmony
+      asyncIterator: t, // proposed? ES-Harmony
       for: t,
       hasInstance: t,
       isConcatSpreadable: t,
@@ -327,14 +335,15 @@ export default {
       toPrimitive: t,
       toStringTag: t,
       unscopables: t,
-      prototype: t
+      prototype: t,
     },
 
-    Error: {  // 19.5
+    Error: {
+      // 19.5
       prototype: {
         name: '*',
-        message: '*'
-      }
+        message: '*',
+      },
     },
     // In ES6 the *Error "subclasses" of Error inherit from Error,
     // since constructor inheritance generally mirrors prototype
@@ -346,50 +355,51 @@ export default {
     // subclasses in sync with the list in debug.js of subclasses to
     // be rewired.
     EvalError: {
-      prototype: t
+      prototype: t,
     },
     RangeError: {
-      prototype: t
+      prototype: t,
     },
     ReferenceError: {
-      prototype: t
+      prototype: t,
     },
     SyntaxError: {
-      prototype: t
+      prototype: t,
     },
     TypeError: {
-      prototype: t
+      prototype: t,
     },
     URIError: {
-      prototype: t
+      prototype: t,
     },
-
 
     // 20 Numbers and Dates
 
-    Number: {  // 20.1
-      EPSILON: t,                    // ES-Harmony
-      isFinite: j,                   // ES-Harmony
-      isInteger: t,                  // ES-Harmony
-      isNaN: j,                      // ES-Harmony
-      isSafeInteger: j,              // ES-Harmony
-      MAX_SAFE_INTEGER: j,           // ES-Harmony
+    Number: {
+      // 20.1
+      EPSILON: t, // ES-Harmony
+      isFinite: j, // ES-Harmony
+      isInteger: t, // ES-Harmony
+      isNaN: j, // ES-Harmony
+      isSafeInteger: j, // ES-Harmony
+      MAX_SAFE_INTEGER: j, // ES-Harmony
       MAX_VALUE: t,
-      MIN_SAFE_INTEGER: j,           // ES-Harmony
+      MIN_SAFE_INTEGER: j, // ES-Harmony
       MIN_VALUE: t,
       NaN: t,
       NEGATIVE_INFINITY: t,
-      parseFloat: t,                 // ES-Harmony
-      parseInt: t,                   // ES-Harmony
+      parseFloat: t, // ES-Harmony
+      parseInt: t, // ES-Harmony
       POSITIVE_INFINITY: t,
       prototype: {
         toExponential: t,
         toFixed: t,
-        toPrecision: t
-      }
+        toPrecision: t,
+      },
     },
 
-    Math: {  // 20.2
+    Math: {
+      // 20.2
       E: j,
       LN10: j,
       LN2: j,
@@ -401,44 +411,45 @@ export default {
 
       abs: j,
       acos: t,
-      acosh: t,                      // ES-Harmony
+      acosh: t, // ES-Harmony
       asin: t,
-      asinh: t,                      // ES-Harmony
+      asinh: t, // ES-Harmony
       atan: t,
-      atanh: t,                      // ES-Harmony
+      atanh: t, // ES-Harmony
       atan2: t,
-      cbrt: t,                       // ES-Harmony
+      cbrt: t, // ES-Harmony
       ceil: j,
-      clz32: t,                      // ES-Harmony
+      clz32: t, // ES-Harmony
       cos: t,
-      cosh: t,                       // ES-Harmony
+      cosh: t, // ES-Harmony
       exp: t,
-      expm1: t,                      // ES-Harmony
+      expm1: t, // ES-Harmony
       floor: j,
-      fround: t,                     // ES-Harmony
-      hypot: t,                      // ES-Harmony
-      imul: t,                       // ES-Harmony
+      fround: t, // ES-Harmony
+      hypot: t, // ES-Harmony
+      imul: t, // ES-Harmony
       log: j,
-      log1p: t,                      // ES-Harmony
-      log10: j,                      // ES-Harmony
-      log2: j,                       // ES-Harmony
+      log1p: t, // ES-Harmony
+      log10: j, // ES-Harmony
+      log2: j, // ES-Harmony
       max: j,
       min: j,
       pow: j,
-      random: t,                     // questionable
+      random: t, // questionable
       round: j,
-      sign: t,                       // ES-Harmony
+      sign: t, // ES-Harmony
       sin: t,
-      sinh: t,                       // ES-Harmony
+      sinh: t, // ES-Harmony
       sqrt: j,
       tan: t,
-      tanh: t,                       // ES-Harmony
-      trunc: j                       // ES-Harmony
+      tanh: t, // ES-Harmony
+      trunc: j, // ES-Harmony
     },
 
     // no-arg Date constructor is questionable
-    Date: {  // 20.3
-      now: t,                        // questionable
+    Date: {
+      // 20.3
+      now: t, // questionable
       parse: t,
       UTC: t,
       prototype: {
@@ -488,37 +499,37 @@ export default {
         // B.2.4
         getYear: t,
         setYear: t,
-        toGMTString: t
-      }
+        toGMTString: t,
+      },
     },
-
 
     // 21 Text Processing
 
-    String: {  // 21.2
+    String: {
+      // 21.2
       fromCharCode: j,
-      fromCodePoint: t,              // ES-Harmony
-      raw: j,                        // ES-Harmony
+      fromCodePoint: t, // ES-Harmony
+      raw: j, // ES-Harmony
       prototype: {
         charAt: t,
         charCodeAt: t,
-        codePointAt: t,              // ES-Harmony
+        codePointAt: t, // ES-Harmony
         concat: t,
-        endsWith: j,                 // ES-Harmony
-        includes: t,                 // ES-Harmony
+        endsWith: j, // ES-Harmony
+        includes: t, // ES-Harmony
         indexOf: j,
         lastIndexOf: j,
         localeCompare: t,
         match: t,
-        normalize: t,                // ES-Harmony
-        padEnd: t,                   // ES-Harmony
-        padStart: t,                 // ES-Harmony
-        repeat: t,                   // ES-Harmony
+        normalize: t, // ES-Harmony
+        padEnd: t, // ES-Harmony
+        padStart: t, // ES-Harmony
+        repeat: t, // ES-Harmony
         replace: t,
         search: t,
         slice: j,
         split: t,
-        startsWith: j,               // ES-Harmony
+        startsWith: j, // ES-Harmony
         substring: t,
         toLocaleLowerCase: t,
         toLocaleUpperCase: t,
@@ -542,61 +553,62 @@ export default {
         sub: t,
         sup: t,
 
-        trimLeft: t,                 // non-standard
-        trimRight: t,                // non-standard
+        trimLeft: t, // non-standard
+        trimRight: t, // non-standard
 
         // 21.1.4 instances
-        length: '*'
-      }
+        length: '*',
+      },
     },
 
-    RegExp: {  // 21.2
+    RegExp: {
+      // 21.2
       prototype: {
         exec: t,
         flags: 'maybeAccessor',
         global: 'maybeAccessor',
         ignoreCase: 'maybeAccessor',
-        [Symbol.match]: '*',         // ES-Harmony
+        [Symbol.match]: '*', // ES-Harmony
         multiline: 'maybeAccessor',
-        [Symbol.replace]: '*',       // ES-Harmony
-        [Symbol.search]: '*',        // ES-Harmony
+        [Symbol.replace]: '*', // ES-Harmony
+        [Symbol.search]: '*', // ES-Harmony
         source: 'maybeAccessor',
-        [Symbol.split]: '*',         // ES-Harmony
+        [Symbol.split]: '*', // ES-Harmony
         sticky: 'maybeAccessor',
         test: t,
-        unicode: 'maybeAccessor',    // ES-Harmony
-        dotAll: 'maybeAccessor',     // proposed ES-Harmony
+        unicode: 'maybeAccessor', // ES-Harmony
+        dotAll: 'maybeAccessor', // proposed ES-Harmony
 
         // B.2.5
-        compile: false,              // UNSAFE. Purposely suppressed
+        compile: false, // UNSAFE. Purposely suppressed
 
         // 21.2.6 instances
         lastIndex: '*',
-        options: '*'                 // non-std
-      }
+        options: '*', // non-std
+      },
     },
-
 
     // 22 Indexed Collections
 
-    Array: {  // 22.1
+    Array: {
+      // 22.1
       from: j,
       isArray: t,
-      of: j,                         // ES-Harmony?
+      of: j, // ES-Harmony?
       prototype: {
         concat: t,
-        copyWithin: t,               // ES-Harmony
-        entries: t,                  // ES-Harmony
+        copyWithin: t, // ES-Harmony
+        entries: t, // ES-Harmony
         every: t,
-        fill: t,                     // ES-Harmony
+        fill: t, // ES-Harmony
         filter: j,
-        find: t,                     // ES-Harmony
-        findIndex: t,                // ES-Harmony
+        find: t, // ES-Harmony
+        findIndex: t, // ES-Harmony
         forEach: j,
-        includes: t,                 // ES-Harmony
+        includes: t, // ES-Harmony
         indexOf: j,
         join: t,
-        keys: t,                     // ES-Harmony
+        keys: t, // ES-Harmony
         lastIndexOf: j,
         map: j,
         pop: j,
@@ -610,11 +622,11 @@ export default {
         sort: t,
         splice: t,
         unshift: j,
-        values: t,                   // ES-Harmony
+        values: t, // ES-Harmony
 
         // 22.1.4 instances
-        length: '*'
-      }
+        length: '*',
+      },
     },
 
     // 22.2 Typed Array stuff
@@ -630,10 +642,10 @@ export default {
     Float32Array: TypedArrayWhitelist,
     Float64Array: TypedArrayWhitelist,
 
-
     // 23 Keyed Collections          all ES-Harmony
 
-    Map: {  // 23.1
+    Map: {
+      // 23.1
       prototype: {
         clear: j,
         delete: j,
@@ -644,11 +656,12 @@ export default {
         keys: j,
         set: j,
         size: 'maybeAccessor',
-        values: j
-      }
+        values: j,
+      },
     },
 
-    Set: {  // 23.2
+    Set: {
+      // 23.2
       prototype: {
         add: j,
         clear: j,
@@ -658,47 +671,50 @@ export default {
         has: j,
         keys: j,
         size: 'maybeAccessor',
-        values: j
-      }
+        values: j,
+      },
     },
 
-    WeakMap: {  // 23.3
+    WeakMap: {
+      // 23.3
       prototype: {
         // Note: coordinate this list with maintenance of repairES5.js
         delete: j,
         get: j,
         has: j,
-        set: j
-      }
+        set: j,
+      },
     },
 
-    WeakSet: {  // 23.4
+    WeakSet: {
+      // 23.4
       prototype: {
         add: j,
         delete: j,
-        has: j
-      }
+        has: j,
+      },
     },
-
 
     // 24 Structured Data
 
-    ArrayBuffer: {  // 24.1            all ES-Harmony
+    ArrayBuffer: {
+      // 24.1            all ES-Harmony
       isView: t,
-      length: t,  // does not inherit from Function.prototype on Chrome
-      name: t,    // ditto
+      length: t, // does not inherit from Function.prototype on Chrome
+      name: t, // ditto
       prototype: {
         byteLength: 'maybeAccessor',
-        slice: t
-      }
+        slice: t,
+      },
     },
 
     // 24.2 TODO: Omitting SharedArrayBuffer for now
 
-    DataView: {  // 24.3               all ES-Harmony
-      length: t,  // does not inherit from Function.prototype on Chrome
-      name: t,    // ditto
-      BYTES_PER_ELEMENT: '*',          // non-standard. really?
+    DataView: {
+      // 24.3               all ES-Harmony
+      length: t, // does not inherit from Function.prototype on Chrome
+      name: t, // ditto
+      BYTES_PER_ELEMENT: '*', // non-standard. really?
       prototype: {
         buffer: 'maybeAccessor',
         byteOffset: 'maybeAccessor',
@@ -718,21 +734,22 @@ export default {
         setInt32: t,
         setUint8: t,
         setUint16: t,
-        setUint32: t
-      }
+        setUint32: t,
+      },
     },
 
     // 24.4 TODO: Omitting Atomics for now
 
-    JSON: {  // 24.5
+    JSON: {
+      // 24.5
       parse: j,
-      stringify: j
+      stringify: j,
     },
-
 
     // 25 Control Abstraction Objects
 
-    Promise: {  // 25.4
+    Promise: {
+      // 25.4
       all: j,
       race: j,
       reject: j,
@@ -740,7 +757,7 @@ export default {
       prototype: {
         catch: t,
         then: j,
-        finally: t,                    // proposed ES-Harmony
+        finally: t, // proposed ES-Harmony
 
         // nanoq.js
         get: t,
@@ -754,8 +771,8 @@ export default {
         // Temporary compat with the old makeQ.js
         send: t,
         delete: t,
-        end: t
-      }
+        end: t,
+      },
     },
 
     // nanoq.js
@@ -779,13 +796,13 @@ export default {
       promise: t,
       delay: t,
       memoize: t,
-      defer: t
+      defer: t,
     },
-
 
     // 26 Reflection
 
-    Reflect: {  // 26.1
+    Reflect: {
+      // 26.1
       apply: t,
       construct: t,
       defineProperty: t,
@@ -798,13 +815,13 @@ export default {
       ownKeys: t,
       preventExtensions: t,
       set: t,
-      setPrototypeOf: t
+      setPrototypeOf: t,
     },
 
-    Proxy: {  // 26.2
-      revocable: t
+    Proxy: {
+      // 26.2
+      revocable: t,
     },
-
 
     // Appendix B
 
@@ -816,28 +833,28 @@ export default {
 
     // Other
 
-    StringMap: {  // A specialized approximation of ES-Harmony's Map.
-      prototype: {} // Technically, the methods should be on the prototype,
-                    // but doing so while preserving encapsulation will be
-                    // needlessly expensive for current usage.
+    StringMap: {
+      // A specialized approximation of ES-Harmony's Map.
+      prototype: {}, // Technically, the methods should be on the prototype,
+      // but doing so while preserving encapsulation will be
+      // needlessly expensive for current usage.
     },
 
     Realm: {
       makeRootRealm: t,
       makeCompartment: t,
       prototype: {
-        global: "maybeAccessor",
-        evaluate: t
-      }
+        global: 'maybeAccessor',
+        evaluate: t,
+      },
     },
 
     SES: {
       confine: t,
-      confineExpr: t
+      confineExpr: t,
     },
 
     Nat: j,
-    def: j
-  }
-
+    def: j,
+  },
 };

--- a/src/commonjs-index.js
+++ b/src/commonjs-index.js
@@ -1,3 +1,3 @@
-const esmRequire = require("esm")(module);
-module.exports = esmRequire("./index.js");
+const esmRequire = require('esm')(module);
 
+module.exports = esmRequire('./index.js');

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@
 
 import SES from './SES.js';
 import { def, Nat } from './bundle/index.js';
+
 const makeSESRootRealm = SES.makeSESRootRealm;
 export default SES;
 export { def, Nat, SES, makeSESRootRealm };
@@ -24,8 +25,7 @@ export { def, Nat, SES, makeSESRootRealm };
 // import {SES, def, Nat} from 'SES';
 
 // f = compileExpr(source); then f(imports) can only affect 'imports'
-//exports.compileExpr = function(exprSrc, opt_mitigateOpts) { };
-
+// exports.compileExpr = function(exprSrc, opt_mitigateOpts) { };
 
 /*
 exports.makeRootSESRealm = function() {

--- a/src/old/ejectorsGuardsTrademarks.js
+++ b/src/old/ejectorsGuardsTrademarks.js
@@ -25,13 +25,12 @@
  * @requires WeakMap, cajaVM
  * @overrides ses, ejectorsGuardsTrademarksModule
  */
-var ses;
+let ses;
 
-(function ejectorsGuardsTrademarksModule(){
-  "use strict";
+(function ejectorsGuardsTrademarksModule() {
+  'use strict';
 
   ses.ejectorsGuardsTrademarks = function ejectorsGuardsTrademarks() {
-
     /**
      * During the call to {@code ejectorsGuardsTrademarks}, {@code
      * ejectorsGuardsTrademarks} must not call {@code cajaVM.def},
@@ -43,27 +42,25 @@ var ses;
      * enough without prematurely freezing primodial objects
      * transitively reachable from these.
      */
-    var freeze = Object.freeze;
-    var constFunc = cajaVM.constFunc;
-
+    const freeze = Object.freeze;
+    const constFunc = cajaVM.constFunc;
 
     /**
      * Returns a new object whose only utility is its identity and (for
      * diagnostic purposes only) its name.
      */
     function Token(name) {
-      name = '' + name;
+      name = `${name}`;
       return freeze({
         toString: constFunc(function tokenToString() {
           return name;
-        })
+        }),
       });
     }
 
-
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
     // Ejectors
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
 
     /**
      * One-arg form is known in scheme as "call with escape
@@ -110,10 +107,14 @@ var ses;
      * rather than a higher order function as here and in call/ec.
      */
     function callWithEjector(attemptFunc, opt_failFunc) {
-      var failFunc = opt_failFunc || function (x) { return x; };
-      var disabled = false;
-      var token = new Token('ejection');
-      var stash = void 0;
+      const failFunc =
+        opt_failFunc ||
+        function(x) {
+          return x;
+        };
+      let disabled = false;
+      const token = new Token('ejection');
+      let stash = void 0;
       function ejector(result) {
         if (disabled) {
           throw new Error('ejector disabled');
@@ -133,9 +134,8 @@ var ses;
       } catch (e) {
         if (e === token) {
           return failFunc(stash);
-        } else {
-          throw e;
         }
+        throw e;
       }
     }
 
@@ -155,15 +155,15 @@ var ses;
       }
     }
 
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
     // Sealing and Unsealing
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
 
     function makeSealerUnsealerPair() {
-      var boxValues = new WeakMap();
+      const boxValues = new WeakMap();
 
       function seal(value) {
-        var box = freeze({});
+        const box = freeze({});
         boxValues.set(box, value);
         return box;
       }
@@ -171,7 +171,7 @@ var ses;
         return boxValues.has(box) ? [boxValues.get(box)] : null;
       }
       function unseal(box) {
-        var result = optUnseal(box);
+        const result = optUnseal(box);
         if (result === null) {
           throw new Error("That wasn't one of my sealed boxes!");
         } else {
@@ -181,16 +181,15 @@ var ses;
       return freeze({
         seal: constFunc(seal),
         unseal: constFunc(unseal),
-        optUnseal: constFunc(optUnseal)
+        optUnseal: constFunc(optUnseal),
       });
     }
 
-
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
     // Trademarks
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
 
-    var stampers = new WeakMap();
+    const stampers = new WeakMap();
 
     /**
      * Internal routine for making a trademark from a table.
@@ -204,10 +203,12 @@ var ses;
      * cajaVM.def}.
      */
     function makeTrademark(typename, table) {
-      typename = '' + typename;
+      typename = `${typename}`;
 
-      var stamp = freeze({
-        toString: constFunc(function() { return typename + 'Stamp'; })
+      const stamp = freeze({
+        toString: constFunc(function() {
+          return `${typename}Stamp`;
+        }),
       });
 
       stampers.set(stamp, function(obj) {
@@ -216,18 +217,24 @@ var ses;
       });
 
       return freeze({
-        toString: constFunc(function() { return typename + 'Mark'; }),
-        stamp: stamp,
+        toString: constFunc(function() {
+          return `${typename}Mark`;
+        }),
+        stamp,
         guard: freeze({
-          toString: constFunc(function() { return typename + 'T'; }),
+          toString: constFunc(function() {
+            return `${typename}T`;
+          }),
           coerce: constFunc(function(specimen, opt_ejector) {
             if (!table.get(specimen)) {
-              eject(opt_ejector,
-                    'Specimen does not have the "' + typename + '" trademark');
+              eject(
+                opt_ejector,
+                `Specimen does not have the "${typename}" trademark`,
+              );
             }
             return specimen;
-          })
-        })
+          }),
+        }),
       });
     }
 
@@ -246,9 +253,9 @@ var ses;
      *     g(x) === x
      * </pre>
      */
-    var GuardMark = makeTrademark('Guard', new WeakMap());
-    var GuardT = GuardMark.guard;
-    var GuardStamp = GuardMark.stamp;
+    const GuardMark = makeTrademark('Guard', new WeakMap());
+    const GuardT = GuardMark.guard;
+    const GuardStamp = GuardMark.stamp;
     stampers.get(GuardStamp)(GuardT);
 
     /**
@@ -268,10 +275,10 @@ var ses;
      * T.ListT.of(cajaVM.GuardT)} represents frozen arrays of guards.
      */
     function Trademark(typename) {
-      var result = makeTrademark(typename, new WeakMap());
+      const result = makeTrademark(typename, new WeakMap());
       stampers.get(GuardStamp)(result.guard);
       return result;
-    };
+    }
 
     /**
      * Given that {@code stamps} is a list of stamps and
@@ -284,16 +291,16 @@ var ses;
     function stamp(stamps, record) {
       // TODO: Should nonextensible objects be stampable?
       if (Object.isFrozen(record)) {
-        throw new TypeError("Can't stamp frozen objects: " + record);
+        throw new TypeError(`Can't stamp frozen objects: ${record}`);
       }
       stamps = Array.prototype.slice.call(stamps, 0);
-      var numStamps = stamps.length;
+      const numStamps = stamps.length;
       // First ensure that we will succeed before applying any stamps to
       // the record.
-      var i;
+      let i;
       for (i = 0; i < numStamps; i++) {
         if (!stampers.has(stamps[i])) {
-          throw new TypeError("Can't stamp with a non-stamp: " + stamps[i]);
+          throw new TypeError(`Can't stamp with a non-stamp: ${stamps[i]}`);
         }
       }
       for (i = 0; i < numStamps; i++) {
@@ -302,11 +309,11 @@ var ses;
         stampers.get(stamps[i])(record);
       }
       return freeze(record);
-    };
+    }
 
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
     // Guards
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
 
     /**
      * First ensures that g is a guard; then does
@@ -335,10 +342,9 @@ var ses;
         }),
         constFunc(function(ignored) {
           return false;
-        })
+        }),
       );
     }
-
 
     /**
      * Create a guard which passes all objects present in {@code table}.
@@ -349,31 +355,33 @@ var ses;
      * when an object does not pass the guard.
      */
     function makeTableGuard(table, typename, errorMessage) {
-      var g = {
-        toString: constFunc(function() { return typename + 'T'; }),
+      const g = {
+        toString: constFunc(function() {
+          return `${typename}T`;
+        }),
         coerce: constFunc(function(specimen, opt_ejector) {
           if (Object(specimen) === specimen && table.get(specimen)) {
             return specimen;
           }
           eject(opt_ejector, errorMessage);
-        })
+        }),
       };
       stamp([GuardStamp], g);
       return freeze(g);
     }
 
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
     // Exporting
-    ////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////
 
     return freeze({
       makeSealerUnsealerPair: constFunc(makeSealerUnsealerPair),
-      GuardT: GuardT,
+      GuardT,
       makeTableGuard: constFunc(makeTableGuard),
       Trademark: constFunc(Trademark),
       guard: constFunc(guard),
       passesGuard: constFunc(passesGuard),
-      stamp: constFunc(stamp)
+      stamp: constFunc(stamp),
     });
   };
 })();

--- a/src/old/frozenRealm.js
+++ b/src/old/frozenRealm.js
@@ -1,5 +1,3 @@
-
 // f2 = tamperProof(f1); now f2 is safe against some things
-exports.tamperProof = function() { };
+exports.tamperProof = function() {};
 exports.constFunc = function() {};
-

--- a/src/old/prepareSESRealm.js
+++ b/src/old/prepareSESRealm.js
@@ -1,4 +1,3 @@
-
 exports.prepareSESRealm = function(global) {
   // hello i am source
   // TODO
@@ -6,9 +5,14 @@ exports.prepareSESRealm = function(global) {
   global.ses = {};
 
   global.ses.spawn = function(endowments = {}) {
-    const c = new Realm({intrinsics: 'inherit'} /* TODO: inherit other stuff */);
+    const c = new Realm(
+      { intrinsics: 'inherit' } /* TODO: inherit other stuff */,
+    );
     // TODO: populate c with new evaluators
-    Object.defineProperties(c.global, Object.getOwnPropertyDescriptors(endowments));
+    Object.defineProperties(
+      c.global,
+      Object.getOwnPropertyDescriptors(endowments),
+    );
     return c;
   };
 

--- a/src/old/scan.js
+++ b/src/old/scan.js
@@ -6,8 +6,12 @@
 // We don't use it in normal operation, but we export it for use in tests
 // (both automatic and manual).
 
-import { getOwnPropertyDescriptors, getPrototypeOf, hasOwnProperty,
-         ownKeys } from './commons';
+import {
+  getOwnPropertyDescriptors,
+  getPrototypeOf,
+  hasOwnProperty,
+  ownKeys,
+} from './commons';
 
 export function walkObjects(start, visitor) {
   const visitQueue = new Map();

--- a/src/old/tamperProof.js
+++ b/src/old/tamperProof.js
@@ -1,4 +1,3 @@
 exports.tamperProofDataProperties = require('../proposal-realms/shim/src/tamper-proof.js').tamperProofDataProperties;
 // TODO: also export tamperProofProperty , will require us to copy tamper-proof.js
 // or get jf to export it for us
-

--- a/test/test-console.js
+++ b/test/test-console.js
@@ -2,28 +2,31 @@ import test from 'tape';
 import SES from '../src/index.js';
 
 test('console disabled by default', function(t) {
-  const s = SES.makeSESRootRealm({errorStackMode: "allow"});
-  t.equal(typeof s.global.console, "undefined");
-  t.throws(() => s.evaluate('console.log("console is missing entirely")'), TypeError);
+  const s = SES.makeSESRootRealm({ errorStackMode: 'allow' });
+  t.equal(typeof s.global.console, 'undefined');
+  t.throws(
+    () => s.evaluate('console.log("console is missing entirely")'),
+    TypeError,
+  );
   t.end();
 });
 
 test('console can be enabled', function(t) {
-  const s = SES.makeSESRootRealm({consoleMode: "allow"});
-  console.log("you should see 6 messages between here:");
+  const s = SES.makeSESRootRealm({ consoleMode: 'allow' });
+  console.log('you should see 6 messages between here:');
   s.evaluate('console.log("1/6 log (internal)")');
-  s.global.console.log("2/6 log (external)");
+  s.global.console.log('2/6 log (external)');
   s.evaluate('console.info("3/6 info")');
   s.evaluate('console.warn("4/6 warn")');
   s.evaluate('console.error("5/6 error")');
   s.evaluate('console.time("6/6 console.time")');
   s.evaluate('console.timeEnd("6/6 console.time")');
-  console.log("and here");
+  console.log('and here');
   t.end();
 });
 
 test('console should be frozen', function(t) {
-  const s = SES.makeSESRootRealm({consoleMode: "allow"});
+  const s = SES.makeSESRootRealm({ consoleMode: 'allow' });
   t.throws(() => s.evaluate('console.forbidden = 4'), TypeError);
   t.throws(() => s.evaluate('console.log = 4'), TypeError);
   t.throws(() => s.evaluate('console.log.forbidden = 4'), TypeError);

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -7,30 +7,30 @@ test('Date.now neutered by default', function(t) {
   const now = s.evaluate('Date.now()');
   t.equal(Number.isNaN(now), true);
   const newDate = s.evaluate('new Date()');
-  t.equal(`${newDate}`, "Invalid Date");
+  t.equal(`${newDate}`, 'Invalid Date');
   t.end();
 });
 
 test('Date.now neutered upon request', function(t) {
-  const s = SES.makeSESRootRealm({dateNowMode: false});
+  const s = SES.makeSESRootRealm({ dateNowMode: false });
   t.equal(s.evaluate('Date.parse("1982-04-09")'), Date.parse('1982-04-09'));
   const now = s.evaluate('Date.now()');
   t.equal(Number.isNaN(now), true);
   const newDate = s.evaluate('new Date()');
-  t.equal(`${newDate}`, "Invalid Date");
+  t.equal(`${newDate}`, 'Invalid Date');
   t.end();
 });
 
 test('Date.now can be left alone', function(t) {
   const start = Date.now();
-  const s = SES.makeSESRootRealm({dateNowMode: "allow"});
+  const s = SES.makeSESRootRealm({ dateNowMode: 'allow' });
   t.equal(s.evaluate('Date.parse("1982-04-09")'), Date.parse('1982-04-09'));
   const now = s.evaluate('Date.now()');
   const finished = Date.now();
   t.assert(Number.isInteger(now));
   t.assert(start <= now <= finished, (start, now, finished));
   const newDate = s.evaluate('new Date()');
-  t.notEqual(`${newDate}`, "Invalid Date");
+  t.notEqual(`${newDate}`, 'Invalid Date');
   t.end();
 });
 
@@ -42,17 +42,17 @@ test('get Date from new SES.makeSESRootRealm', function(t) {
   const now = s2.global.Date.now();
   t.equal(Number.isNaN(now), true);
   const newDate = s2.evaluate('new Date()');
-  t.equal(`${newDate}`, "Invalid Date");
+  t.equal(`${newDate}`, 'Invalid Date');
   t.end();
 });
 
 test('get Date from new Realm', function(t) {
-  const s1 = SES.makeSESRootRealm({dateNowMode: false});
+  const s1 = SES.makeSESRootRealm({ dateNowMode: false });
   const r2 = s1.evaluate('Realm.makeRootRealm()');
   const now = r2.global.Date.now();
-  console.log("now is", now);
+  console.log('now is', now);
   t.equal(Number.isNaN(now), true);
   const newDate = r2.evaluate('new Date()');
-  t.equal(`${newDate}`, "Invalid Date");
+  t.equal(`${newDate}`, 'Invalid Date');
   t.end();
 });

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -8,7 +8,7 @@ test('Error.captureStackTrace neutered by default', function(t) {
 });
 
 test('Error.captureStackTrace neutered upon request', function(t) {
-  const s = SES.makeSESRootRealm({errorStackMode: false});
+  const s = SES.makeSESRootRealm({ errorStackMode: false });
   t.equal(s.evaluate('Error.captureStackTrace'), undefined);
   t.end();
 });
@@ -18,7 +18,7 @@ test('Error.captureStackTrace neutered upon request', function(t) {
 
 test('Error.captureStackTrace can be left alone', function(t) {
   const rootHasCaptureStackTrace = 'captureStackTrace' in Error;
-  const s = SES.makeSESRootRealm({errorStackMode: "allow"});
+  const s = SES.makeSESRootRealm({ errorStackMode: 'allow' });
   const realmHasCaptureStackTrace = s.evaluate('"captureStackTrace" in Error');
   t.equal(rootHasCaptureStackTrace, realmHasCaptureStackTrace);
   t.end();

--- a/test/test-freeze.js
+++ b/test/test-freeze.js
@@ -22,13 +22,34 @@ test('SESRealm named intrinsics are frozen', function(t) {
 test('SESRealm anonymous intrinsics are frozen', function(t) {
   const s = SES.makeSESRootRealm();
   // these two will be frozen once #41 is fixed
-  t.throws(() => s.evaluate('(async function() {}).constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('(async function*() {}).constructor.a = 10;'), TypeError);
+  t.throws(
+    () => s.evaluate('(async function() {}).constructor.a = 10;'),
+    TypeError,
+  );
+  t.throws(
+    () => s.evaluate('(async function*() {}).constructor.a = 10;'),
+    TypeError,
+  );
   t.throws(() => s.evaluate('(function*() {}).constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('[][Symbol.iterator]().constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('new Map()[Symbol.iterator]().constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('new Set()[Symbol.iterator]().constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('new WeakMap()[Symbol.iterator]().constructor.a = 10;'), TypeError);
-  t.throws(() => s.evaluate('new WeakSet()[Symbol.iterator]().constructor.a = 10;'), TypeError);
+  t.throws(
+    () => s.evaluate('[][Symbol.iterator]().constructor.a = 10;'),
+    TypeError,
+  );
+  t.throws(
+    () => s.evaluate('new Map()[Symbol.iterator]().constructor.a = 10;'),
+    TypeError,
+  );
+  t.throws(
+    () => s.evaluate('new Set()[Symbol.iterator]().constructor.a = 10;'),
+    TypeError,
+  );
+  t.throws(
+    () => s.evaluate('new WeakMap()[Symbol.iterator]().constructor.a = 10;'),
+    TypeError,
+  );
+  t.throws(
+    () => s.evaluate('new WeakSet()[Symbol.iterator]().constructor.a = 10;'),
+    TypeError,
+  );
   t.end();
 });

--- a/test/test-math.js
+++ b/test/test-math.js
@@ -8,15 +8,15 @@ test('Math.random neutered by default', function(t) {
 });
 
 test('Math.random neutered upon request', function(t) {
-  const s = SES.makeSESRootRealm({mathRandomMode: false});
+  const s = SES.makeSESRootRealm({ mathRandomMode: false });
   t.throws(() => s.evaluate('Math.random()'), Error);
   t.end();
 });
 
 test('Math.random can be left alone', function(t) {
-  const s = SES.makeSESRootRealm({mathRandomMode: "allow"});
+  const s = SES.makeSESRootRealm({ mathRandomMode: 'allow' });
   const random = s.evaluate('Math.random()');
-  t.equal(typeof random, "number");
+  t.equal(typeof random, 'number');
   t.notOk(Number.isNaN(random));
   t.end();
 });

--- a/test/test-nat.js
+++ b/test/test-nat.js
@@ -4,17 +4,17 @@ import SES from '../src/index.js';
 test('SES environment has Nat', function(t) {
   const s = SES.makeSESRootRealm();
   function check() {
-    const n = (x) => Nat(x);
+    const n = x => Nat(x);
     return { n };
   }
   const { n } = s.evaluate(`${check}; check()`);
   t.equal(n(0), 0);
   t.equal(n(1), 1);
   t.equal(n(999), 999);
-  t.throws(() => n("not a number"), s.global.RangeError);
+  t.throws(() => n('not a number'), s.global.RangeError);
   t.throws(() => n(-1), s.global.RangeError);
   t.throws(() => n(0.5), s.global.RangeError);
-  t.throws(() => n(2**60), s.global.RangeError);
+  t.throws(() => n(2 ** 60), s.global.RangeError);
   t.throws(() => n(NaN), s.global.RangeError);
   t.end();
 });

--- a/test/test-regexp.js
+++ b/test/test-regexp.js
@@ -8,13 +8,13 @@ test('RegExp.compile neutered by default', function(t) {
 });
 
 test('RegExp.compile neutered upon request', function(t) {
-  const s = SES.makeSESRootRealm({regexpMode: false});
+  const s = SES.makeSESRootRealm({ regexpMode: false });
   t.equal(s.evaluate('(new RegExp()).compile'), undefined);
   t.end();
 });
 
 test('RegExp.compile cannot be left alone, even if mode=allow', function(t) {
-  const s = SES.makeSESRootRealm({regexpMode: "allow"});
+  const s = SES.makeSESRootRealm({ regexpMode: 'allow' });
   t.equal(s.evaluate('(new RegExp()).compile'), undefined);
   t.end();
 });

--- a/test/test-removal.js
+++ b/test/test-removal.js
@@ -18,43 +18,40 @@ import SES from '../src/index.js';
 // the Realms shim only populates a new Realm with certain globals, so our
 // whitelist might not actually cause anything to be removed
 
-test('SharedArrayBuffer should be removed because it is not on the whitelist',
-     function(t) {
-       const s = SES.makeSESRootRealm();
-       // we seem to manage both of these for properties that never existed
-       // in the first place
-       t.throws(() => s.evaluate('XYZ'), ReferenceError);
-       t.equal(s.evaluate('typeof XYZ'), 'undefined');
-       let have = typeof SharedArrayBuffer !== 'undefined';
-       if (have) {
-         // we ideally want both of these, but the realms magic can only
-         // manage one at a time (for properties that previously existed but
-         // which were removed by the whitelist check)
-         //t.throws(() => s.evaluate('SharedArrayBuffer'), ReferenceError);
-         t.equal(s.evaluate('typeof SharedArrayBuffer'), 'undefined');
-       }
-       t.end();
-     });
+test('SharedArrayBuffer should be removed because it is not on the whitelist', function(t) {
+  const s = SES.makeSESRootRealm();
+  // we seem to manage both of these for properties that never existed
+  // in the first place
+  t.throws(() => s.evaluate('XYZ'), ReferenceError);
+  t.equal(s.evaluate('typeof XYZ'), 'undefined');
+  const have = typeof SharedArrayBuffer !== 'undefined';
+  if (have) {
+    // we ideally want both of these, but the realms magic can only
+    // manage one at a time (for properties that previously existed but
+    // which were removed by the whitelist check)
+    // t.throws(() => s.evaluate('SharedArrayBuffer'), ReferenceError);
+    t.equal(s.evaluate('typeof SharedArrayBuffer'), 'undefined');
+  }
+  t.end();
+});
 
 // we manually tested that removing e.g. Promise from whitelist.js causes
 // this to behave as expected. To let this be an automatic test, we need
 // something that 1: Realms allows through, 2: our taming shims don't remove,
 // and 3: our whitelist removes.
 function OFFtest() {}
-OFFtest('break something',
-     function(t) {
-       const s = SES.makeSESRootRealm();
-       t.equal(s.evaluate('typeof Promise'), 'undefined');
-       t.end();
-     });
+OFFtest('break something', function(t) {
+  const s = SES.makeSESRootRealm();
+  t.equal(s.evaluate('typeof Promise'), 'undefined');
+  t.end();
+});
 
 // the Realms shim allows regexps to have a 'compile' method, but SES removes
 // it. This gets removed twice: once in tame-regexp, and again by the
 // whitelist.
 
-test('remove RegExp.prototype.compile',
-     function(t) {
-       const s = SES.makeSESRootRealm();
-       t.equal(s.evaluate('const r = /./; typeof r.compile'), 'undefined');
-       t.end();
-     });
+test('remove RegExp.prototype.compile', function(t) {
+  const s = SES.makeSESRootRealm();
+  t.equal(s.evaluate('const r = /./; typeof r.compile'), 'undefined');
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ test('create', function(t) {
 });
 
 test('SESRealm does not see primal realm names', function(t) {
-  let hidden = 1;
+  const hidden = 1;
   const s = SES.makeSESRootRealm();
   t.throws(() => s.evaluate('hidden+1'), ReferenceError);
   t.end();
@@ -19,7 +19,10 @@ test('SESRealm also has SES', function(t) {
   const s = SES.makeSESRootRealm();
   t.equal(1, 1);
   t.equal(s.evaluate('1+1'), 2);
-  t.equal(s.evaluate(`const s2 = SES.makeSESRootRealm(); s2.evaluate('1+2')`), 3);
+  t.equal(
+    s.evaluate(`const s2 = SES.makeSESRootRealm(); s2.evaluate('1+2')`),
+    3,
+  );
   t.end();
 });
 
@@ -47,7 +50,7 @@ test('SESRealm has SES.confine', function(t) {
 test('SESRealm.SES wraps exceptions', function(t) {
   const s = SES.makeSESRootRealm();
   function fail() {
-      missing;
+    missing;
   }
   function check(failStr) {
     try {
@@ -61,7 +64,10 @@ test('SESRealm.SES wraps exceptions', function(t) {
     return 'did not throw';
   }
   const failStr = `${fail}; fail()`;
-  t.equal(s.evaluate(`${check}; check(failStr)`, { failStr }), 'inner ReferenceError');
+  t.equal(
+    s.evaluate(`${check}; check(failStr)`, { failStr }),
+    'inner ReferenceError',
+  );
   t.end();
 });
 
@@ -90,4 +96,3 @@ test('main use case', function(t) {
   t.throws(() => user(-1), s.global.TypeError);
   t.end();
 });
-


### PR DESCRIPTION
This PR turns off a couple of the ESLint rules that we will eventually want, in order to only change whitespace and other things that should not effect the functionality. 

It applies `npm run lint-fix` and `npm run pretty-fix`