### PR TITLE
add require('nat') to the environment if requireMode:'allow'

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -105,7 +105,7 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       };
       // TODO: workaround for eval() being rewritten in s
       sources.natF = r.evaluate(`(${sources.nat})`);
-      //console.log(`makeRequire src is ${s}`);
+      // console.log(`makeRequire src is ${s}`);
       r.global.require = r.evaluate(s)(sources, r.global.def);
     }
 

--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -23,6 +23,7 @@ import { deepFreeze } from './deepFreeze';
 import hardenPrimordials from './hardenPrimordials';
 import whitelist from './whitelist';
 import makeConsole from './make-console';
+import makeRequire from './make-require';
 
 export function createSESWithRealmConstructor(creatorStrings, Realm) {
   function makeSESRootRealm(options) {
@@ -95,6 +96,17 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
     if (options.consoleMode === 'allow') {
       const s = `(${makeConsole})`;
       r.global.console = r.evaluate(s)(console);
+    }
+
+    if (options.requireMode === 'allow') {
+      const s = `(${makeRequire})`;
+      const sources = {
+        nat: `${b.Nat}`,
+      };
+      // TODO: workaround for eval() being rewritten in s
+      sources.natF = r.evaluate(`(${sources.nat})`);
+      //console.log(`makeRequire src is ${s}`);
+      r.global.require = r.evaluate(s)(sources, r.global.def);
     }
 
     // Finally freeze all the primordials, and the global object. This must

--- a/src/bundle/make-require.js
+++ b/src/bundle/make-require.js
@@ -1,0 +1,22 @@
+export default function makeRequire(sources, def) {
+  const cache = new Map();
+  function newRequire(what) {
+    //console.log(`newRequire ${what}`);
+    if (!cache.has(what)) {
+      let mod;
+      if (what === 'nat') {
+        // I want to do this, at least for pure modules:
+        //mod = eval(sources['nat']);
+        // but that gets rewritten into something like
+        // "_d62.u(eval(_d62.c(sources['nat'])))"
+        mod = sources.natF;
+      } else {
+        throw new Error(`Cannot find module '${what}'`);
+      }
+      cache.set(what, def(mod));
+    }
+    return cache.get(what);
+  }
+
+  return newRequire;
+}

--- a/src/bundle/make-require.js
+++ b/src/bundle/make-require.js
@@ -1,12 +1,12 @@
 export default function makeRequire(sources, def) {
   const cache = new Map();
   function newRequire(what) {
-    //console.log(`newRequire ${what}`);
+    // console.log(`newRequire ${what}`);
     if (!cache.has(what)) {
       let mod;
       if (what === 'nat') {
         // I want to do this, at least for pure modules:
-        //mod = eval(sources['nat']);
+        // mod = eval(sources['nat']);
         // but that gets rewritten into something like
         // "_d62.u(eval(_d62.c(sources['nat'])))"
         mod = sources.natF;

--- a/test/test-require.js
+++ b/test/test-require.js
@@ -8,22 +8,22 @@ test('SES environment lacks require by default', t => {
 });
 
 test('SES environment can have require(nat)', t => {
-  const s = SES.makeSESRootRealm({requireMode: 'allow', errorStackMode: 'allow', consoleMode: 'allow'});
-  t.notEqual(typeof s.global.require, 'undefined');
+  const s = SES.makeSESRootRealm({ requireMode: 'allow' });
+  t.equal(typeof s.global.require, 'function');
   function check() {
+    // eslint-disable-next-line global-require,import/no-unresolved
     const Nat = require('nat');
-    //console.log(`Nat is ${typeof Nat}`);
-    const n = x => Nat(x); // eslint-disable-line no-undef
+    const n = x => Nat(x);
     return { n, Nat };
   }
-  //console.log(`REQ src is ${check}`);
+  // console.log(`REQ src is ${check}`);
   const { n, Nat: n2 } = s.evaluate(`(${check})()`);
-  //console.log(`Nat is ${typeof n2}`);
+  // console.log(`Nat is ${typeof n2}`);
   t.equal(typeof n2, 'function');
   t.equal(n(0), 0);
   t.equal(n(1), 1);
   t.equal(n(999), 999);
-  t.equal(n((2**53)-1), (2**53)-1);
+  t.equal(n(2 ** 53 - 1), 2 ** 53 - 1);
   t.throws(() => n('not a number'), s.global.RangeError);
   t.throws(() => n(-1), s.global.RangeError);
   t.throws(() => n(0.5), s.global.RangeError);

--- a/test/test-require.js
+++ b/test/test-require.js
@@ -1,0 +1,34 @@
+import test from 'tape';
+import { SES } from '../src/index';
+
+test('SES environment lacks require by default', t => {
+  const s = SES.makeSESRootRealm();
+  t.equal(typeof s.global.require, 'undefined');
+  t.end();
+});
+
+test('SES environment can have require(nat)', t => {
+  const s = SES.makeSESRootRealm({requireMode: 'allow', errorStackMode: 'allow', consoleMode: 'allow'});
+  t.notEqual(typeof s.global.require, 'undefined');
+  function check() {
+    const Nat = require('nat');
+    //console.log(`Nat is ${typeof Nat}`);
+    const n = x => Nat(x); // eslint-disable-line no-undef
+    return { n, Nat };
+  }
+  //console.log(`REQ src is ${check}`);
+  const { n, Nat: n2 } = s.evaluate(`(${check})()`);
+  //console.log(`Nat is ${typeof n2}`);
+  t.equal(typeof n2, 'function');
+  t.equal(n(0), 0);
+  t.equal(n(1), 1);
+  t.equal(n(999), 999);
+  t.equal(n((2**53)-1), (2**53)-1);
+  t.throws(() => n('not a number'), s.global.RangeError);
+  t.throws(() => n(-1), s.global.RangeError);
+  t.throws(() => n(0.5), s.global.RangeError);
+  t.throws(() => n(2 ** 53), s.global.RangeError);
+  t.throws(() => n(2 ** 60), s.global.RangeError);
+  t.throws(() => n(NaN), s.global.RangeError);
+  t.end();
+});


### PR DESCRIPTION
There's an esm-related name-mangling problem still pending, so this patch
can't use a simple lazy eval() yet. Instead, we use r.evaluate() from
outside, then pass the new Nat() function into makeRequire(). This forces us
to evaluate the function when creating the SES realm, even if nobody ever
calls require() with 'nat'. Once we figure out that problem, we can revert to
the simpler/lazier version.

refs #51