### PR TITLE
test-console: test that SES.confine includes console.log too

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -588,9 +588,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.4.tgz",
-      "integrity": "sha512-wOuWtQCkkwD1WKQN/k3RsyGSSN+AmiUzdKftn8vaC+uV9JesYmQlODJxgXaaRz0LaaFIlUxZaUu5NPiUAjKAAA=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.5.tgz",
+      "integrity": "sha512-rukU6Nd3agbHQCJWV4rrlZxqpbO3ix8qhUxK1BhKALGS2E465O0BFwgCOqJjNnYfO/I2MwpUBmPsW8DXoe8tcA=="
     },
     "espree": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@agoric/nat": "^2.0.0",
-    "esm": "^3.2.4"
+    "esm": "^3.2.5"
   },
   "repository": {
     "type": "git",

--- a/test/test-console.js
+++ b/test/test-console.js
@@ -32,3 +32,26 @@ test('console should be frozen', t => {
   t.throws(() => s.evaluate('console.log.forbidden = 4'), TypeError);
   t.end();
 });
+
+test('console is available to multiply-confined code', t => {
+  const s = SES.makeSESRootRealm({ consoleMode: 'allow' });
+  console.log('you should see 3 messages between here:');
+  function t3() {
+    console.log('3/3 hello from t3');
+  }
+  function t2(t3src) {
+    console.log('2/3 hello from t2');
+    SES.confine(t3src)();
+  }
+  function t1(t2src, t3src) {
+    console.log('1/3 hello from t1');
+    SES.confine(t2src)(t3src);
+  }
+  const t1Src = `(${t1})`;
+  const t2Src = `(${t2})`;
+  const t3Src = `(${t3})`;
+  const t1func = s.evaluate(t1Src);
+  t1func(t2Src, t3Src);
+  console.log('and here');
+  t.end();
+});


### PR DESCRIPTION
Upgrade to esm@3.2.5 to avoid a "console gets renamed by esm" problem, which
would otherwise break the new test.