### PR TITLE
remove Nat from global, use require('@agoric/nat') to get it

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -91,7 +91,6 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
     b.createSESInThisRealm(r.global, creatorStrings, r);
     // b.removeProperties(r.global);
     r.global.def = b.def;
-    r.global.Nat = b.Nat;
 
     if (options.consoleMode === 'allow') {
       const s = `(${makeConsole})`;

--- a/src/bundle/make-require.js
+++ b/src/bundle/make-require.js
@@ -4,7 +4,7 @@ export default function makeRequire(sources, def) {
     // console.log(`newRequire ${what}`);
     if (!cache.has(what)) {
       let mod;
-      if (what === 'nat') {
+      if (what === '@agoric/nat') {
         // I want to do this, at least for pure modules:
         // mod = eval(sources['nat']);
         // but that gets rewritten into something like

--- a/test/test-nat.js
+++ b/test/test-nat.js
@@ -1,20 +1,15 @@
 import test from 'tape';
 import { SES } from '../src/index';
 
-test('SES environment has Nat', t => {
+test('SES environment does not have Nat as a global', t => {
   const s = SES.makeSESRootRealm();
+  t.equal(typeof s.global.Nat, 'undefined');
   function check() {
     const n = x => Nat(x); // eslint-disable-line no-undef
     return { n };
   }
   const { n } = s.evaluate(`${check}; check()`);
-  t.equal(n(0), 0);
-  t.equal(n(1), 1);
-  t.equal(n(999), 999);
-  t.throws(() => n('not a number'), s.global.RangeError);
-  t.throws(() => n(-1), s.global.RangeError);
-  t.throws(() => n(0.5), s.global.RangeError);
-  t.throws(() => n(2 ** 60), s.global.RangeError);
-  t.throws(() => n(NaN), s.global.RangeError);
+
+  t.throws(() => n(0), s.global.ReferenceError);
   t.end();
 });

--- a/test/test-require.js
+++ b/test/test-require.js
@@ -12,7 +12,7 @@ test('SES environment can have require(nat)', t => {
   t.equal(typeof s.global.require, 'function');
   function check() {
     // eslint-disable-next-line global-require,import/no-unresolved
-    const Nat = require('nat');
+    const Nat = require('@agoric/nat');
     const n = x => Nat(x);
     return { n, Nat };
   }


### PR DESCRIPTION
In the longer run, Nat will be removed from SES entirely, and a more generic
approach to require() will allow e.g. PlaygroundVat to provide it as a global
to imported code. But for now, changing this name to match the NPM package
name should let us start writing code that works in both modes.