### PR TITLE
anonIntrinsics: add AsyncIteratorPrototype

### DIFF
--- a/src/bundle/anonIntrinsics.js
+++ b/src/bundle/anonIntrinsics.js
@@ -227,7 +227,7 @@ export default function getAnonIntrinsics(global) {
     const AsyncGeneratorFunction = AsyncGenerator.constructor;
     if (getProto(AsyncGeneratorFunction) !== Function.prototype.constructor) {
       throw new Error(
-        'GeneratorFunction.__proto__ was not Function.prototype.constructor',
+        'AsyncGeneratorFunction.__proto__ was not Function.prototype.constructor',
       );
     }
     result.AsyncGeneratorFunction = AsyncGeneratorFunction;

--- a/src/bundle/anonIntrinsics.js
+++ b/src/bundle/anonIntrinsics.js
@@ -231,14 +231,16 @@ export default function getAnonIntrinsics(global) {
       );
     }
     result.AsyncGeneratorFunction = AsyncGeneratorFunction;
+    const AsyncGeneratorPrototype = AsyncGenerator.prototype;
+    result.AsyncIteratorPrototype = getProto(AsyncGeneratorPrototype);
     // it appears that the only way to get an AsyncIteratorPrototype is
     // through this getProto() process, so there's nothing to check it
     // against
-    /*
-      const agenProtoBase = getProto(AsyncGenerator.prototype);
-      if (agenProtoBase !== result.AsyncIteratorPrototype) {
-        throw new Error('Unexpected AsyncGenerator.prototype.__proto__');
-      } */
+    if (getProto(result.AsyncIteratorPrototype) !== Object.prototype) {
+      throw new Error(
+        'AsyncIteratorPrototype.__proto__ was not Object.prototype',
+      );
+    }
 
     // Get the ES6 %AsyncFunction% intrinsic, if present.
     if (getProto(AsyncFunctionPrototype) !== Function.prototype) {

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -134,6 +134,8 @@ export default {
     StringIteratorPrototype: {},
     MapIteratorPrototype: {},
     SetIteratorPrototype: {},
+    // AsyncIteratorPrototype does not inherit from IteratorPrototype
+    AsyncIteratorPrototype: {},
 
     // The %GeneratorFunction% intrinsic is the constructor of
     // generator functions, so %GeneratorFunction%.prototype is


### PR DESCRIPTION
We were missing AsyncIteratorPrototype, which is the
prototype (getPrototypeOf) of AsyncGeneratorPrototype, which is
the (dot)prototype of AsyncGenerator. Our current deepFreeze follows both
sorts of links, so AsyncIteratorPrototype was being frozen, but the new
version (harden) doesn't follow getPrototypeOf, so it wouldn't have been
frozen there.

Also add AsyncIteratorPrototype to the whitelist so it will be retained.

refs #58