### PR TITLE
standardize applied eslint rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@
 /dist/ses-shim.js.map
 /src/stringifiedBundle
 /src/old/
+/demo/
+/scripts/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,7 @@
 module.exports = {
   extends: ['airbnb', 'plugin:prettier/recommended'],
   env: {
-    es6: true,
-    mocha: true,
+    es6: true, // supports new ES6 globals (e.g., new types such as Set)
   },
   rules: {
     'implicit-arrow-linebreak': 'off',
@@ -10,6 +9,10 @@ module.exports = {
     'arrow-parens': 'off',
     strict: 'off',
     'no-console': 'off',
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-return-assign': 'off',
+    'no-param-reassign': 'off',
+    'no-restricted-syntax': ['off', 'ForOfStatement'],
+    'import/prefer-default-export': 'off', // contrary to Agoric standard
   },
 };
-

--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
     "just-test": "tape -r esm test/**/*.js",
     "build-intermediate": "node scripts/build-intermediate.js",
     "build": "git submodule update --init --recursive && node scripts/build-intermediate.js && rollup -c",
-    "pretty-fix": "prettier --write 'src/**/*.{js,jsx}' 'test/**/*.{js,jsx}'",
-    "pretty-check": "prettier --check 'src/**/*.{js,jsx}' 'test/**/*.{js,jsx}'",
-    "lint-fix": "eslint --fix 'src/**/*.{js,jsx}' 'test/**/*.{js,jsx}'",
-    "lint-check": "eslint 'src/**/*.{js,jsx}' 'test/**/*.{js,jsx}'"
+    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
+    "lint-check": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
     "@agoric/nat": "^2.0.0",


### PR DESCRIPTION
adds demo and scripts to .eslintignore instead of having a different npm script command