### PR TITLE
Test Multiple Versions of Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
       - build-node-9
       - build-node-10
       - build-node-11
-      - success
+      - success:
         requires:
           - build-node-10
           - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,5 @@ workflows:
     requires:
       - build-node-10
       - build-node-11
+    jobs:
+      - success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.0
 jobs:
-  build-node-7: &default
+  build-node-11: &default
     docker:
       - image: circleci/node:7
     steps:
@@ -27,38 +27,30 @@ jobs:
       - run:
           name: Test
           command: npm test
-  build-node-8:
-    <<: *default
-    docker:
-      - image: circleci/node:8
-  build-node-9:
-    <<: *default
-    docker:
-      - image: circleci/node:9
   build-node-10:
     <<: *default
     docker:
-      - image: circleci/node:10
-  build-node-11:
-    <<: *default
-    docker:
-      - image: circleci/node:11
-  success:
-    steps:
-      - run:
-          name: Success
-          command: echo success
+      - image: circleci/node:8
+  # build-node-9:
+  #   <<: *default
+  #   docker:
+  #     - image: circleci/node:9
+  # build-node-8:
+  #   <<: *default
+  #   docker:
+  #     - image: circleci/node:10
+  # build-node-7:
+  #   <<: *default
+  #   docker:
+  #     - image: circleci/node:11
+
 
 workflows:
   version: 2
   test-all-versions:
     jobs:
-      - build-node-7
-      - build-node-8
-      - build-node-9
+      # - build-node-7
+      # - build-node-8
+      # - build-node-9
       - build-node-10
       - build-node-11
-      - success:
-        requires:
-          - build-node-10
-          - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,7 @@ workflows:
       - build-node-9
       - build-node-10
       - build-node-11
-  success:
-    requires:
-      - build-node-10
-      - build-node-11
-    jobs:
       - success
+        requires:
+          - build-node-10
+          - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,7 @@ workflows:
       - build-node-9
       - build-node-10
       - build-node-11
+  success:
+    requires:
+      - build-node-10
+      - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,29 @@
 version: 2.0
 jobs:
-  build:
+  build-node-7:
+    docker:
+      - image: circleci/node:7
+    steps:
+      <<: *build_steps
+  build-node-8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      <<: *build_steps
+  build-node-9:
+    docker:
+      - image: circleci/node:9
+    steps:
+      <<: *build_steps
+  build-node-10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      <<: *build_steps
+  build-node-11:
     docker:
       - image: circleci/node:11
-    steps:
+    steps: &build_steps
       - checkout # special step to check out source code to working directory
       - run:
           name: Update npm
@@ -27,3 +47,12 @@ jobs:
       - run:
           name: Test
           command: npm test
+
+workflows:
+  version: 2
+  jobs:
+    - build-node-7
+    - build-node-8
+    - build-node-9
+    - build-node-10
+    - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build-node-11: &default
     docker:
-      - image: circleci/node:7
+      - image: circleci/node:11
     steps:
       - checkout # special step to check out source code to working directory
       - run:
@@ -30,7 +30,7 @@ jobs:
   build-node-10:
     <<: *default
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
   # build-node-9:
   #   <<: *default
   #   docker:
@@ -38,11 +38,11 @@ jobs:
   # build-node-8:
   #   <<: *default
   #   docker:
-  #     - image: circleci/node:10
+  #     - image: circleci/node:8
   # build-node-7:
   #   <<: *default
   #   docker:
-  #     - image: circleci/node:11
+  #     - image: circleci/node:7
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,6 @@ jobs:
   build-node-7:
     docker:
       - image: circleci/node:7
-    steps:
-      <<: *build_steps
-  build-node-8:
-    docker:
-      - image: circleci/node:8
-    steps:
-      <<: *build_steps
-  build-node-9:
-    docker:
-      - image: circleci/node:9
-    steps:
-      <<: *build_steps
-  build-node-10:
-    docker:
-      - image: circleci/node:10
-    steps:
-      <<: *build_steps
-  build-node-11:
-    docker:
-      - image: circleci/node:11
     steps: &build_steps
       - checkout # special step to check out source code to working directory
       - run:
@@ -47,6 +27,26 @@ jobs:
       - run:
           name: Test
           command: npm test
+  build-node-8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      <<: *build_steps
+  build-node-9:
+    docker:
+      - image: circleci/node:9
+    steps:
+      <<: *build_steps
+  build-node-10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      <<: *build_steps
+  build-node-11:
+    docker:
+      - image: circleci/node:11
+    steps:
+      <<: *build_steps
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,10 @@ jobs:
 
 workflows:
   version: 2
-  jobs:
-    - build-node-7
-    - build-node-8
-    - build-node-9
-    - build-node-10
-    - build-node-11
+  test-all-versions:
+    jobs:
+      - build-node-7
+      - build-node-8
+      - build-node-9
+      - build-node-10
+      - build-node-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,11 @@ jobs:
     <<: *default
     docker:
       - image: circleci/node:11
+  success:
+    steps:
+      - run:
+          name: Success
+          command: echo success
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.0
 jobs:
-  build-node-7:
+  build-node-7: &default
     docker:
       - image: circleci/node:7
-    steps: &build_steps
+    steps:
       - checkout # special step to check out source code to working directory
       - run:
           name: Update npm
@@ -28,25 +28,21 @@ jobs:
           name: Test
           command: npm test
   build-node-8:
+    <<: *default
     docker:
       - image: circleci/node:8
-    steps:
-      <<: *build_steps
   build-node-9:
+    <<: *default
     docker:
       - image: circleci/node:9
-    steps:
-      <<: *build_steps
   build-node-10:
+    <<: *default
     docker:
       - image: circleci/node:10
-    steps:
-      <<: *build_steps
   build-node-11:
+    <<: *default
     docker:
       - image: circleci/node:11
-    steps:
-      <<: *build_steps
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description
This PR adds configurations to the CircleCI config.yml to test versions 7, 8, 9, 10, and 11 of Node.js. However, CircleCI does not currently have an `allow_failure` mode, so if any tests fail, the whole process fails in CircleCI. We know that the test suite will fail on Node 7, 8, and 9, so for now, those jobs are commented out. When we do want to test those versions, we can uncomment those jobs on those branches. It's a bit hacky, but I think it's the only solution for now. 

## Tests
Check that CircleCI is only running the jobs for Node.js version 10 and 11, and that everything passes. 