### PR TITLE
Add Symbol.matchAll to whitelist

### DIFF
--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -330,6 +330,7 @@ export default {
       iterator: t,
       keyFor: t,
       match: t,
+      matchAll: t,
       replace: t,
       search: t,
       species: t,


### PR DESCRIPTION
This PR adds a line for `matchAll`. 

`Symbol.matchAll` is present in Chrome 73, and its presence without being on the whitelist or otherwise handled causes SES to error (see Issue #90). 

Closes #90 