### PR TITLE
Fixes to endowment safety example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -75,8 +75,8 @@ function makeConsole() {
   }
 }
 
-const newConsole = s.evaluate(`(${makeConsole})`, {consoleEndowment: console});
-s.evaluate('console.log(4)', { console: newConsole() });
+const newConsole = s.evaluate(`(${makeConsole}())`, {consoleEndowment: console});
+s.evaluate('console.log(4)', { console: newConsole });
 ```
 
 Wrapping endowments like this is critical for security, because the simple approach would reveal an outer-realm object to the confined code, which it could use to escape confinement:
@@ -87,7 +87,7 @@ function evil() {
   outerObject.__proto__.toString = obj => 'haha';
 }
 
-s.evaluate(`(${evil})`, { consoleEndowment: console })();
+s.evaluate(`(${evil}())`, { consoleEndowment: console });
 (()=>{}).toString(); // prints 'haha'
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,7 +76,7 @@ function makeConsole() {
 }
 
 const newConsole = s.evaluate(`(${makeConsole})`, {consoleEndowment: console});
-s.evaluate('console.log(4)', { console: newConsole });
+s.evaluate('console.log(4)', { console: newConsole() });
 ```
 
 Wrapping endowments like this is critical for security, because the simple approach would reveal an outer-realm object to the confined code, which it could use to escape confinement:
@@ -87,8 +87,8 @@ function evil() {
   outerObject.__proto__.toString = obj => 'haha';
 }
 
-s.evaluate(`(${evil})`, { consoleEndowment: console });
-{}.toString(); // prints 'haha'
+s.evaluate(`(${evil})`, { consoleEndowment: console })();
+(()=>{}).toString(); // prints 'haha'
 ```
 
 The key is that we evaluate trusted code to generate the safe endowment, and only pass the safe endowment to the untrusted code. Every object in the system should be examined to identify which realm it is coming from (outer or inner), and never ever reveal outer-realm objects to untrusted code. Even passing a collection of safe inner-realm objects to untrusted code enables a confinement breach:


### PR DESCRIPTION
Tried evaluating the example in the docs and found it was missing a few calls, and replacing the `toString` of `Function.prototype` rather than `Object.prototype`.