### PR TITLE
Fix "Uncaught undefined" in Chrome.

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -173,7 +173,7 @@ export function createSESInThisRealm(global, creatorStrings, parentRealm) {
         // they aren't useful for an attack.
         eName = `${err.name}`;
         eMessage = `${err.message}`;
-        eStack = `${err.stack}`;
+        eStack = `${err.stack || eMessage}`;
         // eName/eMessage/eStack are now child-realm primitive strings, and
         // safe to expose
       } catch (ignored) {

--- a/src/bundle/make-console.js
+++ b/src/bundle/make-console.js
@@ -42,7 +42,7 @@ export default function makeConsole(parentConsole) {
         // they aren't useful for an attack.
         eName = `${err.name}`;
         eMessage = `${err.message}`;
-        eStack = `${err.stack}`;
+        eStack = `${err.stack || eMessage}`;
         // eName/eMessage/eStack are now child-realm primitive strings, and
         // safe to expose
       } catch (ignored) {


### PR DESCRIPTION
See also: https://github.com/tc39/proposal-realms/pull/207

When the err.stack is undefined, Chrome will only display Uncaught undefined instead of the error message. This patch adds in the error message if the stack is not set so that there is a better diagnostic.

