### PR TITLE
FIX: change SES script in demo to point to unpkg

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -4,10 +4,16 @@ This directory contains a brief online demonstration of how SES enables safe
 interaction between mutually suspicious code. Visit
 https://rawgit.com/Agoric/SES/master/demo/ to run it.
 
-For local testing, run a web server and serve the entire git tree (the demo
-accesses the generated ``ROOT/dist/ses-shim.js`` file, so serving just this
-``demo/`` directory is not enough). Re-run ``npm run-script build`` after any
-changes to the source code to rebuild ``ses-shim.js``.
+For convenience, the demo imports SES from unpkg, but to avoid relying
+upon a third party for security, your production applications should
+publish and reference their own copy of ses.umd.js.
+
+For local testing, after making a change, run ``npm run-script
+build`` to build the generated files. Then, ensure that the demo is
+pointing towards your generated file (i.e.``<script src="../dist/ses.umd.js"></script>
+``). Next, run a web server and serve the entire git tree.  (the demo
+accesses the generated ``ROOT/dist/ses.umd.js`` file, so serving just this
+``demo/`` directory is not enough). 
 
 ## Would You Like To Play A Game?
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,7 @@
 <head>
  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
  <title>Testing SES</title>
- <script src="../dist/ses.umd.js"></script>
+ <script src="https://unpkg.com/ses"></script>
  <link href="style.css" rel="stylesheet" type="text/css" />
  <!-- Global site tag (gtag.js) - Google Analytics -->
  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118217811-2"></script>


### PR DESCRIPTION
This PR makes a change to the demo to pull in SES from unpkg.

Originally, the demo was using the SES file generated by rollup and committed to the repo. Then, when we started to have a policy of `gitignore`-ing the generated files, the demo [got a 404 for SES](https://github.com/Agoric/SES/issues/91#issuecomment-480127922), since the generated files were not built or present in the repo. This fixes that 404 error. 

## Considerations
I used a floating reference to SES. `https://unpkg.com/ses` will resolve to the latest version. This has the benefit of not having to remember to change the version number on each new release. However, I could also see the possibility of having a preference for the pinned version, e.g. `https://unpkg.com/ses@0.5.0/dist/ses.umd.js`