### PR TITLE
options.transforms: forward to Realm.makeRootRealm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.5.0",
+  "version": "0.5.0+dev",
   "description": "Secure ECMAScript",
   "main": "dist/ses.cjs.js",
   "module": "dist/ses.esm.js",

--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -32,6 +32,8 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
     const shims = [];
     const wl = JSON.parse(JSON.stringify(whitelist));
 
+    const { transforms, shims: optionalShims } = options;
+
     // "allow" enables real Date.now(), anything else gets NaN
     // (it'd be nice to allow a fixed numeric value, but too hard to
     // implement right now)
@@ -85,7 +87,12 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
                (${removeProperties})(this, ${JSON.stringify(wl)})`;
     shims.push(removeProp);
 
-    const r = Realm.makeRootRealm({ shims });
+    // Add options.shims.
+    if (optionalShims) {
+      shims.push(...optionalShims);
+    }
+
+    const r = Realm.makeRootRealm({ shims, transforms });
 
     // Build a harden() with an empty fringe. It will be populated later when
     // we call harden(allIntrinsics).
@@ -112,7 +119,6 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
 
     // build the makeRequire helper, glue it to the new Realm
     r.makeRequire = harden(r.evaluate(`(${makeMakeRequire})`)(r, harden));
-
     return r;
   }
   const SES = {

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -757,23 +757,26 @@ export default {
       race: j,
       reject: j,
       resolve: j,
+      makeHandled: t, // eventual-send
       prototype: {
         catch: t,
         then: j,
         finally: t, // proposed ES-Harmony
 
-        // nanoq.js
+        // eventual-send
+        delete: t,
         get: t,
         put: t,
-        del: t,
         post: t,
         invoke: t,
         fapply: t,
         fcall: t,
 
+        // nanoq.js
+        del: t,
+
         // Temporary compat with the old makeQ.js
         send: t,
-        delete: t,
         end: t,
       },
     },


### PR DESCRIPTION
This feature is used by the [@agoric/transform-bang](https://github.com/Agoric/transform-bang) transformer, and will also be used by the future `@agoric/transform-module`.

The transforms themselves are entirely implemented in realms-shim, so all we need to do is pass through the option.