### PR TITLE
whitelist: allow realms-shim indirect eval

### DIFF
--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -236,8 +236,7 @@ export default {
     undefined: j,
 
     // 18.2
-    // eval: t,                      // Whitelisting under separate control
-    // by TAME_GLOBAL_EVAL in startSES.js
+    eval: j, // realms-shim depends on having indirect eval in the globals
     isFinite: t,
     isNaN: t,
     parseFloat: t,

--- a/test/test-removal.js
+++ b/test/test-removal.js
@@ -17,6 +17,16 @@ import SES from '../src/index';
 
 // the Realms shim only populates a new Realm with certain globals, so our
 // whitelist might not actually cause anything to be removed
+test('indirect eval is possible', t => {
+  try {
+    const s = SES.makeSESRootRealm();
+    t.equal(s.evaluate(`(1,eval)('123')`), 123, 'indirect eval succeeds');
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
 
 test('SharedArrayBuffer should be removed because it is not on the whitelist', t => {
   const s = SES.makeSESRootRealm();


### PR DESCRIPTION
createSESRootRealm was preventing indirect eval from working, since realms-shim puts the `eval` definition in the globals.  The absence of `eval` from the whitelist meant that SES would happily remove the definition.

This may be handled differently in the future if we decide to put `eval` in the scopeTarget instead of the safeGlobal.

closes https://github.com/Agoric/realms-shim/issues/25
