### PR TITLE
test-post-release.js: don't test stale unpkg uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,5 +211,16 @@ workflows:
                  - master
      jobs:
         - npm_audit_node_11
-        - post_release_test_integration_node_11
-        - post_release_test_integration_node_10
+        # Only do the post-release tests for the release tags.
+        - post_release_test_integration_node_11:
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+        - post_release_test_integration_node_10:
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/


### PR DESCRIPTION
We're getting false failures from the nightly post-release test because the development version of SES is not uploaded to NPM.

This condition ensures we only test NPM releases after they've been uploaded.

There may be a better way to solve this.
