### PR TITLE
options.sloppyGlobals: reject, since our realm is frozen

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -25,7 +25,7 @@ import whitelist from './whitelist';
 import makeConsole from './make-console';
 import makeMakeRequire from './make-require';
 
-const FORWARDED_REALMS_OPTIONS = ['sloppyGlobals', 'transforms'];
+const FORWARDED_REALMS_OPTIONS = ['transforms'];
 
 export function createSESWithRealmConstructor(creatorStrings, Realm) {
   function makeSESRootRealm(options) {
@@ -35,6 +35,7 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
 
     const {
       shims: optionalShims,
+      sloppyGlobals,
       whitelist: optWhitelist,
       ...optionsRest
     } = options;
@@ -48,6 +49,12 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
         realmsOptions[key] = optionsRest[key];
       }
     });
+
+    if (sloppyGlobals) {
+      throw TypeError(
+        `sloppyGlobals cannot be specified on frozen Realms (like SES)`,
+      );
+    }
 
     // "allow" enables real Date.now(), anything else gets NaN
     // (it'd be nice to allow a fixed numeric value, but too hard to


### PR DESCRIPTION
Reject SES root realm options.sloppyGlobals, since they should be using a Compartment where global assignments can be honoured.
