### PR TITLE
Workaround for override mistake

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -24,7 +24,7 @@ import getAllPrimordials from './getAllPrimordials';
 import whitelist from './whitelist';
 import makeConsole from './make-console';
 import makeMakeRequire from './make-require';
-import { repairDataProperties } from './mutable';
+import makeRepairDataProperties from './mutable';
 
 
 const FORWARDED_REALMS_OPTIONS = ['sloppyGlobals', 'transforms'];
@@ -111,6 +111,9 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
 
     const r = Realm.makeRootRealm({ ...realmsOptions, shims });
 
+    const makeRepairDataPropertiesSrc = `(${makeRepairDataProperties})`
+    const repairDataProperties = r.evaluate(makeRepairDataPropertiesSrc)()
+
     // Build a harden() with an empty fringe. It will be populated later when
     // we call harden(allIntrinsics).
     const makeHardenerSrc = `(${makeHardener})`;
@@ -132,6 +135,7 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       r.global,
       anonIntrinsics,
     );
+
     repairDataProperties(allIntrinsics);
     harden(allIntrinsics);
 

--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -24,6 +24,8 @@ import getAllPrimordials from './getAllPrimordials';
 import whitelist from './whitelist';
 import makeConsole from './make-console';
 import makeMakeRequire from './make-require';
+import { repairDataProperties } from './mutable';
+
 
 const FORWARDED_REALMS_OPTIONS = ['sloppyGlobals', 'transforms'];
 
@@ -130,6 +132,7 @@ export function createSESWithRealmConstructor(creatorStrings, Realm) {
       r.global,
       anonIntrinsics,
     );
+    repairDataProperties(allIntrinsics);
     harden(allIntrinsics);
 
     // build the makeRequire helper, glue it to the new Realm

--- a/src/bundle/mutable.js
+++ b/src/bundle/mutable.js
@@ -4,13 +4,12 @@
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
 
 import {
-  defineProperty,
+  defineProperties,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
-  getOwnPropertyNames,
-  getOwnPropertySymbols,
+  ownKeys,
   objectHasOwnProperty
-} from '../realms-shim/src/commons';
+} from '../../realms-shim/src/commons';
 
 
 /**
@@ -79,8 +78,7 @@ export function beMutableProperties(obj) {
   if (!descs) {
     return;
   }
-  getOwnPropertyNames(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
-  getOwnPropertySymbols(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
+  ownKeys(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
 }
 
 export function beMutableProperty(obj, prop) {
@@ -93,41 +91,47 @@ export function beMutableProperty(obj, prop) {
  * and must be converted before freezing.
  */
 export function repairDataProperties(intrinsics) {
-  const i = intrinsics;
+  const { global: g, anonIntrinsics: a } = intrinsics;
 
   [
-    i.ObjectPrototype,
-    i.ArrayPrototype,
-    i.BooleanPrototype,
-    i.DatePrototype,
-    i.NumberPrototype,
-    i.StringPrototype,
+    g.Object.prototype,
+    g.Array.prototype,
+    g.Boolean.prototype,
+    g.Date.prototype,
+    g.Number.prototype,
+    g.String.prototype,
 
-    i.FunctionPrototype,
-    i.GeneratorPrototype,
-    i.AsyncFunctionPrototype,
-    i.AsyncGeneratorPrototype,
+    g.Function.prototype,
+    a.GeneratorFunction.prototype,
+    a.AsyncFunction.prototype,
+    a.AsyncGeneratorFunction.prototype,
 
-    i.IteratorPrototype,
-    i.ArrayIteratorPrototype,
+    a.IteratorPrototype,
+    a.ArrayIteratorPrototype,
 
-    i.PromisePrototype,
-    i.DataViewPrototype,
+    g.Promise.prototype,
+    g.DataView.prototype,
 
-    i.TypedArray,
-    i.Int8ArrayPrototype,
-    i.Int16ArrayPrototype,
-    i.Int32ArrayPrototype,
-    i.Uint8Array,
-    i.Uint16Array,
-    i.Uint32Array,
+    a.TypedArray,
+    g.Int8Array.prototype,
+    g.Int16Array.prototype,
+    g.Int32Array.prototype,
+    g.Uint8Array,
+    g.Uint16Array,
+    g.Uint32Array,
 
-    i.ErrorPrototype,
-    i.EvalErrorPrototype,
-    i.RangeErrorPrototype,
-    i.ReferenceErrorPrototype,
-    i.SyntaxErrorPrototype,
-    i.TypeErrorPrototype,
-    i.URIErrorPrototype
+    g.Error.prototype,
+    g.EvalError.prototype,
+    g.RangeError.prototype,
+    g.ReferenceError.prototype,
+    g.SyntaxError.prototype,
+    g.TypeError.prototype,
+    g.URIError.prototype
   ].forEach(beMutableProperties);
+}
+
+// Object.defineProperty is allowed to fail silently,
+// wrap Object.defineProperties instead.
+function defineProperty (obj, prop, desc) {
+  defineProperties(obj, { [prop]: desc });
 }

--- a/src/bundle/mutable.js
+++ b/src/bundle/mutable.js
@@ -3,135 +3,146 @@
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
 
-import {
-  defineProperties,
-  getOwnPropertyDescriptor,
-  getOwnPropertyDescriptors,
-  ownKeys,
-  objectHasOwnProperty
-} from '../../realms-shim/src/commons';
+export default function makeRepairDataProperties () {
 
+  const {
+    defineProperties,
+    getOwnPropertyDescriptor,
+    getOwnPropertyDescriptors,
+    hasOwnProperty
+  } = Object;
+  const { ownKeys } = Reflect;
 
-/**
- * For a special set of properties (defined below), it ensures that the
- * effect of freezing does not suppress the ability to override these
- * properties on derived objects by simple assignment.
- *
- * Because of lack of sufficient foresight at the time, ES5 unfortunately
- * specified that a simple assignment to a non-existent property must fail if
- * it would override a non-writable data property of the same name. (In
- * retrospect, this was a mistake, but it is now too late and we must live
- * with the consequences.) As a result, simply freezing an object to make it
- * tamper proof has the unfortunate side effect of breaking previously correct
- * code that is considered to have followed JS best practices, if this
- * previous code used assignment to override.
- *
- * To work around this mistake, deepFreeze(), prior to freezing, replaces
- * selected configurable own data properties with accessor properties which
- * simulate what we should have specified -- that assignments to derived
- * objects succeed if otherwise possible.
- */
-function beMutable(obj, prop, desc) {
-  if ('value' in desc && desc.configurable) {
-    const value = desc.value;
+  /**
+   * For a special set of properties (defined below), it ensures that the
+   * effect of freezing does not suppress the ability to override these
+   * properties on derived objects by simple assignment.
+   *
+   * Because of lack of sufficient foresight at the time, ES5 unfortunately
+   * specified that a simple assignment to a non-existent property must fail if
+   * it would override a non-writable data property of the same name. (In
+   * retrospect, this was a mistake, but it is now too late and we must live
+   * with the consequences.) As a result, simply freezing an object to make it
+   * tamper proof has the unfortunate side effect of breaking previously correct
+   * code that is considered to have followed JS best practices, if this
+   * previous code used assignment to override.
+   *
+   * To work around this mistake, deepFreeze(), prior to freezing, replaces
+   * selected configurable own data properties with accessor properties which
+   * simulate what we should have specified -- that assignments to derived
+   * objects succeed if otherwise possible.
+   */
+  function beMutable(obj, prop, desc) {
+    if ('value' in desc && desc.configurable) {
+      const value = desc.value;
 
-    // eslint-disable-next-line no-inner-declarations
-    function getter() {
-      return value;
+      // eslint-disable-next-line no-inner-declarations
+      function getter() {
+        return value;
+      }
+
+      // Re-attach the data property on the object so
+      // it can be found by the deep-freeze traversal process.
+      getter.value = value;
+
+      // eslint-disable-next-line no-inner-declarations
+      function setter(newValue) {
+        if (obj === this) {
+          throw new TypeError(`Cannot assign to read only property '${prop}' of object '${obj}'`);
+        }
+        if (hasOwnProperty.call(this, prop)) {
+          this[prop] = newValue;
+        } else {
+          defineProperty(this, prop, {
+            value: newValue,
+            writable: true,
+            enumerable: desc.enumerable,
+            configurable: desc.configurable
+          });
+        }
+      }
+
+      defineProperty(obj, prop, {
+        get: getter,
+        set: setter,
+        enumerable: desc.enumerable,
+        configurable: desc.configurable
+      });
+    }
+  }
+
+  function beMutableProperties(obj) {
+    if (!obj) {
+      return;
+    }
+    const descs = getOwnPropertyDescriptors(obj);
+    if (!descs) {
+      return;
+    }
+    ownKeys(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
+  }
+
+  function beMutableProperty(obj, prop) {
+    const desc = getOwnPropertyDescriptor(obj, prop);
+    beMutable(obj, prop, desc);
+  }
+
+  /**
+   * These properties are subject to the override mistake
+   * and must be converted before freezing.
+   */
+  function repairDataProperties(intrinsics) {
+    const { global: g, anonIntrinsics: a } = intrinsics;
+
+    const toBeRepaired = [
+      g.Object.prototype,
+      g.Array.prototype,
+      g.Boolean.prototype,
+      g.Date.prototype,
+      g.Number.prototype,
+      g.String.prototype,
+
+      g.Function.prototype,
+      a.GeneratorFunction.prototype,
+      a.AsyncFunction.prototype,
+      a.AsyncGeneratorFunction.prototype,
+
+      a.IteratorPrototype,
+      a.ArrayIteratorPrototype,
+
+      g.DataView.prototype,
+
+      a.TypedArray,
+      g.Int8Array.prototype,
+      g.Int16Array.prototype,
+      g.Int32Array.prototype,
+      g.Uint8Array,
+      g.Uint16Array,
+      g.Uint32Array,
+
+      g.Error.prototype,
+      g.EvalError.prototype,
+      g.RangeError.prototype,
+      g.ReferenceError.prototype,
+      g.SyntaxError.prototype,
+      g.TypeError.prototype,
+      g.URIError.prototype
+    ]
+
+    // Promise may be removed from the whitelist
+    const PromisePrototype = g.Promise && g.Promise.prototype;
+    if (PromisePrototype) {
+      toBeRepaired.push(PromisePrototype)
     }
 
-    // Re-attach the data property on the object so
-    // it can be found by the deep-freeze traversal process.
-    getter.value = value;
-
-    // eslint-disable-next-line no-inner-declarations
-    function setter(newValue) {
-      if (obj === this) {
-        throw new TypeError(`Cannot assign to read only property '${prop}' of object '${obj}'`);
-      }
-      if (objectHasOwnProperty.call(this, prop)) {
-        this[prop] = newValue;
-      } else {
-        defineProperty(this, prop, {
-          value: newValue,
-          writable: true,
-          enumerable: desc.enumerable,
-          configurable: desc.configurable
-        });
-      }
-    }
-
-    defineProperty(obj, prop, {
-      get: getter,
-      set: setter,
-      enumerable: desc.enumerable,
-      configurable: desc.configurable
-    });
+    toBeRepaired.forEach(beMutableProperties);
   }
-}
 
-export function beMutableProperties(obj) {
-  if (!obj) {
-    return;
+  // Object.defineProperty is allowed to fail silently,
+  // wrap Object.defineProperties instead.
+  function defineProperty (obj, prop, desc) {
+    defineProperties(obj, { [prop]: desc });
   }
-  const descs = getOwnPropertyDescriptors(obj);
-  if (!descs) {
-    return;
-  }
-  ownKeys(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
-}
 
-export function beMutableProperty(obj, prop) {
-  const desc = getOwnPropertyDescriptor(obj, prop);
-  beMutable(obj, prop, desc);
-}
-
-/**
- * These properties are subject to the override mistake
- * and must be converted before freezing.
- */
-export function repairDataProperties(intrinsics) {
-  const { global: g, anonIntrinsics: a } = intrinsics;
-
-  [
-    g.Object.prototype,
-    g.Array.prototype,
-    g.Boolean.prototype,
-    g.Date.prototype,
-    g.Number.prototype,
-    g.String.prototype,
-
-    g.Function.prototype,
-    a.GeneratorFunction.prototype,
-    a.AsyncFunction.prototype,
-    a.AsyncGeneratorFunction.prototype,
-
-    a.IteratorPrototype,
-    a.ArrayIteratorPrototype,
-
-    g.Promise.prototype,
-    g.DataView.prototype,
-
-    a.TypedArray,
-    g.Int8Array.prototype,
-    g.Int16Array.prototype,
-    g.Int32Array.prototype,
-    g.Uint8Array,
-    g.Uint16Array,
-    g.Uint32Array,
-
-    g.Error.prototype,
-    g.EvalError.prototype,
-    g.RangeError.prototype,
-    g.ReferenceError.prototype,
-    g.SyntaxError.prototype,
-    g.TypeError.prototype,
-    g.URIError.prototype
-  ].forEach(beMutableProperties);
-}
-
-// Object.defineProperty is allowed to fail silently,
-// wrap Object.defineProperties instead.
-function defineProperty (obj, prop, desc) {
-  defineProperties(obj, { [prop]: desc });
+  return repairDataProperties;
 }

--- a/src/bundle/mutable.js
+++ b/src/bundle/mutable.js
@@ -1,0 +1,133 @@
+// Adapted from SES/Caja
+// Copyright (C) 2011 Google Inc.
+// https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
+// https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
+
+import {
+  defineProperty,
+  getOwnPropertyDescriptor,
+  getOwnPropertyDescriptors,
+  getOwnPropertyNames,
+  getOwnPropertySymbols,
+  objectHasOwnProperty
+} from '../realms-shim/src/commons';
+
+
+/**
+ * For a special set of properties (defined below), it ensures that the
+ * effect of freezing does not suppress the ability to override these
+ * properties on derived objects by simple assignment.
+ *
+ * Because of lack of sufficient foresight at the time, ES5 unfortunately
+ * specified that a simple assignment to a non-existent property must fail if
+ * it would override a non-writable data property of the same name. (In
+ * retrospect, this was a mistake, but it is now too late and we must live
+ * with the consequences.) As a result, simply freezing an object to make it
+ * tamper proof has the unfortunate side effect of breaking previously correct
+ * code that is considered to have followed JS best practices, if this
+ * previous code used assignment to override.
+ *
+ * To work around this mistake, deepFreeze(), prior to freezing, replaces
+ * selected configurable own data properties with accessor properties which
+ * simulate what we should have specified -- that assignments to derived
+ * objects succeed if otherwise possible.
+ */
+function beMutable(obj, prop, desc) {
+  if ('value' in desc && desc.configurable) {
+    const value = desc.value;
+
+    // eslint-disable-next-line no-inner-declarations
+    function getter() {
+      return value;
+    }
+
+    // Re-attach the data property on the object so
+    // it can be found by the deep-freeze traversal process.
+    getter.value = value;
+
+    // eslint-disable-next-line no-inner-declarations
+    function setter(newValue) {
+      if (obj === this) {
+        throw new TypeError(`Cannot assign to read only property '${prop}' of object '${obj}'`);
+      }
+      if (objectHasOwnProperty.call(this, prop)) {
+        this[prop] = newValue;
+      } else {
+        defineProperty(this, prop, {
+          value: newValue,
+          writable: true,
+          enumerable: desc.enumerable,
+          configurable: desc.configurable
+        });
+      }
+    }
+
+    defineProperty(obj, prop, {
+      get: getter,
+      set: setter,
+      enumerable: desc.enumerable,
+      configurable: desc.configurable
+    });
+  }
+}
+
+export function beMutableProperties(obj) {
+  if (!obj) {
+    return;
+  }
+  const descs = getOwnPropertyDescriptors(obj);
+  if (!descs) {
+    return;
+  }
+  getOwnPropertyNames(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
+  getOwnPropertySymbols(obj).forEach(prop => beMutable(obj, prop, descs[prop]));
+}
+
+export function beMutableProperty(obj, prop) {
+  const desc = getOwnPropertyDescriptor(obj, prop);
+  beMutable(obj, prop, desc);
+}
+
+/**
+ * These properties are subject to the override mistake
+ * and must be converted before freezing.
+ */
+export function repairDataProperties(intrinsics) {
+  const i = intrinsics;
+
+  [
+    i.ObjectPrototype,
+    i.ArrayPrototype,
+    i.BooleanPrototype,
+    i.DatePrototype,
+    i.NumberPrototype,
+    i.StringPrototype,
+
+    i.FunctionPrototype,
+    i.GeneratorPrototype,
+    i.AsyncFunctionPrototype,
+    i.AsyncGeneratorPrototype,
+
+    i.IteratorPrototype,
+    i.ArrayIteratorPrototype,
+
+    i.PromisePrototype,
+    i.DataViewPrototype,
+
+    i.TypedArray,
+    i.Int8ArrayPrototype,
+    i.Int16ArrayPrototype,
+    i.Int32ArrayPrototype,
+    i.Uint8Array,
+    i.Uint16Array,
+    i.Uint32Array,
+
+    i.ErrorPrototype,
+    i.EvalErrorPrototype,
+    i.RangeErrorPrototype,
+    i.ReferenceErrorPrototype,
+    i.SyntaxErrorPrototype,
+    i.TypeErrorPrototype,
+    i.URIErrorPrototype
+  ].forEach(beMutableProperties);
+}


### PR DESCRIPTION
Fixes #12 

introduces `repairDataProperties` originally from [tc39/proposal-ses](https://github.com/tc39/proposal-ses/blob/4a26c7de8c999106733fba85bdd425419472852a/shim/src/mutable.js) and adapts it to meet current `SES`.

A few notes for review:
- need to adjust/update copyright info? file has been modified
- currently only handling dynamic presence of `Promise` (there's a test for it), need to expand?
- want a more minimal toBeRepaired set? #12 has suggestions