### PR TITLE
createSES.js: create a global SES.harden

### DIFF
--- a/src/bundle/createSES.js
+++ b/src/bundle/createSES.js
@@ -133,7 +133,9 @@ You probably want a Compartment instead, like:
 
     const b = r.evaluate(creatorStrings);
     b.createSESInThisRealm(r.global, creatorStrings, r);
-    // b.removeProperties(r.global);
+
+    // Allow harden to be accessible via the SES global.
+    r.global.SES.harden = harden;
 
     if (options.consoleMode === 'allow') {
       const s = `(${makeConsole})`;

--- a/src/bundle/whitelist.js
+++ b/src/bundle/whitelist.js
@@ -859,6 +859,7 @@ export default {
     SES: {
       confine: t,
       confineExpr: t,
+      harden: t,
     },
 
     Nat: j,

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,15 @@ test('SESRealm has SES.confine', t => {
   t.end();
 });
 
+test('SESRealm.SES has harden', t => {
+  const s = SES.makeSESRootRealm();
+  const obj = s.evaluate(`SES.harden({a})`, { a: 123 });
+  t.equal(obj.a, 123, `expected object`);
+  t.throws(() => (obj.a = 'ignored'));
+  t.equal(obj.a, 123, `hardened object retains value`);
+  t.end();
+});
+
 test('SESRealm.SES wraps exceptions', t => {
   const s = SES.makeSESRootRealm();
   function fail() {


### PR DESCRIPTION
This global `SES.harden` property is useful to allow code to harden objects when running under SES.

Specifically, I would like to use it in the HandledPromise implementation so that in non-SES environments hardening is stubbed out with an Object.freeze, and we do not have a dependency on an `@agoric/harden` module import to harden under SES (where the hardening behaviour is mandatory).

I can then do module code like:

```js
const harden = globalThis.SES && globalThis.SES.harden || Object.freeze;
```
