### PR TITLE
repair Error.prototype.toString

### DIFF
--- a/src/bundle/dataPropertiesToRepair.js
+++ b/src/bundle/dataPropertiesToRepair.js
@@ -91,6 +91,7 @@ export default {
         constructor: t, // set by "fast-json-patch"
         message: t,
         name: t, // set by "precond"
+        toString: t, // set by "bluebird"
       },
     },
 


### PR DESCRIPTION
npm package `bluebird` and others create custom Error objects and expect to be able to set `MyError.prototype.toString`.