### PR TITLE
repair TypeError.prototype

### DIFF
--- a/src/bundle/dataPropertiesToRepair.js
+++ b/src/bundle/dataPropertiesToRepair.js
@@ -94,6 +94,13 @@ export default {
         toString: t, // set by "bluebird"
       },
     },
+    
+    TypeError: {
+      prototype: {
+        constructor: t, // set by "readable-stream"
+        name: t, // set by "readable-stream"
+      },
+    },
 
     Promise: {
       prototype: {

--- a/src/bundle/dataPropertiesToRepair.js
+++ b/src/bundle/dataPropertiesToRepair.js
@@ -94,7 +94,7 @@ export default {
         toString: t, // set by "bluebird"
       },
     },
-    
+
     TypeError: {
       prototype: {
         constructor: t, // set by "readable-stream"


### PR DESCRIPTION
`readable-stream` (~39 mil downloads / week) creates subclasses of TypeError using function class inheritance
https://github.com/nodejs/readable-stream/blob/edd8c2d87c0f43f4f1d78407ac972fc193e45b40/errors-browser.js#L3
https://github.com/nodejs/readable-stream/blob/edd8c2d87c0f43f4f1d78407ac972fc193e45b40/errors-browser.js#L32-L33


cc @dckc 